### PR TITLE
Multithreading support 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MAGEMin_C"
 uuid = "e5d170eb-415a-4524-987b-12f1bce1ddab"
 authors = ["Boris Kaus <kaus@uni-mainz.de> & Nicolas Riel <riel@uni-mainz.de>"]
-version = "1.3.2"
+version = "1.3.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -12,4 +12,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 CEnum = "0.4"
 MAGEMin_jll = "1.3.1"
+ProgressMeter = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,10 @@ version = "1.3.2"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 MAGEMin_jll = "763ebaa8-b0d2-5f6b-90ef-4fc23b5db1c4"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-MAGEMin_jll = "1.3.1"
 CEnum = "0.4"
+MAGEMin_jll = "1.3.1"
 julia = "1.6"
-
-

--- a/README.md
+++ b/README.md
@@ -21,141 +21,108 @@ pkg> test MAGEMin_C
 
 By pushing `backspace` you return from the package manager to the main julia terminal. This will download a compiled version of the library as well as some wrapper functions to your system.
 
-Next, you can do calculations with
-### Example 1
-
+Next, you can do calculations with:
+### Example 1 - predefined compositions
 This is an example of how to use it for a predefined bulk rock composition:
 ```julia
-julia> gv, z_b, DB, splx_data      = init_MAGEMin();
-julia> test        = 0;
-julia> sys_in      = "mol"     #default is mol, if wt is provided conversion will be done internally (MAGEMin works on mol basis)
-julia> gv          = use_predefined_bulk_rock(gv, test);
-julia> P           = 8.0;
-julia> T           = 800.0;
-julia> gv.verbose  = -1;        # switch off any verbose
-julia> out         = point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in)
-Pressure          : 8.0      [kbar]
-Temperature       : 800.0    [Celcius]
-     Stable phase | Fraction (mol 1 atom basis) 
-              opx   0.24229 
-               ol   0.58808 
-              cpx   0.14165 
-              spn   0.02798 
-     Stable phase | Fraction (wt fraction) 
-              opx   0.23908 
-               ol   0.58673 
-              cpx   0.14583 
-              spn   0.02846 
-Gibbs free energy : -797.749183  (26 iterations; 94.95 ms)
-Oxygen fugacity          : 9.645393319147175e-12
+julia> db   = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
+julia> DAT  = Initialize_MAGEMin(db, verbose=true);
+julia> test = 0         #KLB1
+julia> DAT  = use_predefined_bulk_rock(DAT, test);
+julia> P    = 8.0;
+julia> T    = 800.0;
+julia> out  = point_wise_minimization(P,T, DAT);
+ Status             :            0 
+ Mass residual      : +8.03033e-06
+ Rank               :            0 
+ Point              :            1 
+ Temperature        :   +800.00000       [C] 
+ Pressure           :     +8.00000       [kbar]
+
+ SOL = [G: -797.749] (26 iterations, 40.98 ms)
+ GAM = [-979.481479,-1774.104933,-795.260896,-673.747606,-375.066863,-917.567179,-829.994361,-1023.642804,-257.017193,-1308.294760]
+
+ Phase :      opx       ol      cpx      spn 
+ Mode  :  0.24229  0.58808  0.14165  0.02798 
 ```
 
-### Example 2
+### Example 2 - custom composition
 And here a case in which you specify your own bulk rock composition. 
-We convert that in the correct format, using the `convertBulk4MAGEMin` function. 
 ```julia
 julia> using MAGEMin_C
-julia> gv, z_b, DB, splx_data      = init_MAGEMin();
-julia> bulk_in_ox = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
-julia> bulk_in    = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
-julia> sys_in     = "wt"
-julia> bulk_rock  = convertBulk4MAGEMin(bulk_in,bulk_in_ox,sys_in);
-julia> gv         = define_bulk_rock(gv, bulk_rock);
-julia> P,T         = 10.0, 1100.0;
-julia> gv.verbose  = -1;        # switch off any verbose
-julia> out         = point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in)
-Pressure          : 10.0      [kbar]
+julia> DAT     = Initialize_MAGEMin("ig", verbose=false);
+julia> n       = 1
+julia> P,T     = fill(10.0,n),fill(1100.0,n)
+julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
+julia> X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
+julia> sys_in  = "wt"    
+julia> out     = multi_point_minimization(P, T, DAT, X=X, Xoxides=Xoxides, sys_in=sys_in)
+1-element Vector{MAGEMin_C.gmin_struct{Float64, Int64}}:
+ Pressure          : 10.0      [kbar]
 Temperature       : 1100.0    [Celcius]
      Stable phase | Fraction (mol 1 atom basis) 
-             pl4T   0.01114 
-              liq   0.74789 
-              cpx   0.21862 
-              opx   0.02154 
+              liq   0.74181 
+              cpx   0.17388 
+             pl4T   0.05116 
      Stable phase | Fraction (wt fraction) 
-             pl4T   0.01168 
-              liq   0.72576 
-              cpx   0.23872 
-              opx   0.02277 
-Gibbs free energy : -907.27887  (47 iterations; 187.11 ms)
-Oxygen fugacity          : 0.02411835177808492
+              liq   0.71562 
+              cpx   0.19051 
+             pl4T   0.05365 
+Gibbs free energy : -907.383224  (24 iterations; 36.74 ms)
+Oxygen fugacity          : 2.8850338669861964e-9
 ```
+Note that we here employ the function `multi_point_minimization`, which will run in parallel if you do it for a large number of points (see below). It will require to pass `P`,`T` as vectors and returns a vector with results.
 
 After the calculation is finished, the structure `out` holds all the information about the stable assemblage, including seismic velocities, melt content, melt chemistry, densities etc.
 You can show a full overview of that with
 ```julia
-julia> print_info(out)
+julia> print_info(out[1])
 ```
 If you are interested in the density or seismic velocity at the point,  access it with
 ```julia
-julia> out.rho
+julia> out[1].rho
 3144.282577840362
-julia> out.Vp
+julia> out[1].Vp
 5.919986959559542
 ```
 Once you are done with all calculations, release the memory with
 ```julia
-julia> finalize_MAGEMin(gv,DB)
+julia> Finalize_MAGEMin(DAT)
 ```
 
 
+### Example 3 - many points
 
+```julia
+julia> db   = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
+julia> DAT  = Initialize_MAGEMin(db, verbose=false);
+julia> test = 0         #KLB1
+julia> n    = 1000 
+julia> P    = rand(8.0:40,n);
+julia> T    = rand(800.0:2000.0, n);
+julia> out  = multi_point_minimization(P,T, DAT, test=test);
+```
+By default, this will show a progressbar (which you can deactivate with the `progressbar=false` option).
 
-## Installing it on HPC systems
+You can also specify a custom bulk rock for all points (see above), or a custom bulk rock for every point.
 
-Essentially all high-performance computer systems currently available use MPI versions that are specifically compiled for that system. As a result, you typically have to recompile your code using those MPI libraries for it to work. In the case of `MAGEMin`, this involves compiling `NLopt` and using the correct `BLAS/LAPACK` libraries as well, which can be sometimes cumbersome.
-
-Luckily there is a solution thanks to the great work of `@eschnett` and colleagues, who developed [MPITrampoline](https://github.com/eschnett/MPItrampoline) which is an intermediate layer between the HPC-system-specific MPI libraries and the precompiled `MAGEMin` binaries. 
-
-It essentially consists of two steps: 1) compile a small package ([MPIwrapper](https://github.com/eschnett/MPIwrapper)), and 2) make sure that you download the version of `MAGEMin` that was compiled versus `MPItrampoline`.
-
-Here step-by-step instructions (for linux, as that is what essentially all HPC systems use):
-
-1) Download [MPIwrapper](https://github.com/eschnett/MPIwrapper): 
+### Running it in parallel
+Julia can be run in parallel using multi-threading. To take advantage of this, you need to start julia from the terminal with:
 ```bash
-$git clone https://github.com/eschnett/MPIwrapper.git 
-$cd MPIwrapper
+$julia -t auto
 ```
-
-2) Install it after making sure that `mpiexec` points to the one you want (you may have to load some modules, depending on your system):
-```bash
-cmake -S . -B build -DMPIEXEC_EXECUTABLE=mpiexec -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/mpiwrapper
-cmake --build build
-cmake --install build
+which will automatically use all threads on your machine. Alternatively, use `julia -t 4` to start it on 4 threads.
+If you are interested to see what you can do on your machine, type:
 ```
-At this stage, `MPItrampoline` is installed in `$HOME/mpiwrapper`
-
-3) Set the correct wrapper:
-```
-$export MPITRAMPOLINE_LIB=$HOME/mpiwrapper/lib64/libmpiwrapper.so
-```
-Depending on the system it may be called `lib` instead of `lib64` (check!).
-
-4) Start julia and install the `MPI` and `MPIPreferences` packages:
-```julia
-$julia
-julia> ]
-pkg>add MPI, MPIPreferences
-```
-
-5) Set the preference to use `MPItrampoline`
-```julia
-julia> using MPIPreferences; MPIPreferences.use_jll_binary("MPItrampoline_jll")
-┌ Info: MPIPreferences unchanged
-└   binary = "MPItrampoline_jll"
-```
-
-6) Load `MPI` and verify it is the correct one
-```julia
-julia> using MPI
-julia> MPI.Get_library_version()
-"MPIwrapper 2.10.3, using MPIABI 2.9.0, wrapping:\nOpen MPI v4.1.4, package: Open MPI boris@Pluton Distribution, ident: 4.1.4, repo rev: v4.1.4, May 26, 2022"
-```
-After this, restart julia.
-
-7) Now load `MAGEMin_jll` and check that it uses the `mpitrampoline` version:
-```julia
-julia> using MAGEMin_jll
-julia> MAGEMin_jll.host_platform
-Linux x86_64 {cxxstring_abi=cxx11, julia_version=1.8.1, libc=glibc, libgfortran_version=5.0.0, mpi=mpitrampoline}
-```
-And you are all set!
+julia> versioninfo()
+Julia Version 1.9.0
+Commit 8e630552924 (2023-05-07 11:25 UTC)
+Platform Info:
+  OS: macOS (arm64-apple-darwin22.4.0)
+  CPU: 12 × Apple M2 Max
+  WORD_SIZE: 64
+  LIBM: libopenlibm
+  LLVM: libLLVM-14.0.6 (ORCJIT, apple-m1)
+  Threads: 8 on 8 virtual cores
+``` 
+The function `multi_point_minimization` will automatically utilize parallelization if you run it on >1 threads.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ julia> Finalize_MAGEMin(DAT)
 ### Example 3 - many points
 
 ```julia
+julia> using MAGEMin_C
 julia> db   = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
 julia> DAT  = Initialize_MAGEMin(db, verbose=false);
 julia> test = 0         #KLB1
@@ -101,6 +102,7 @@ julia> n    = 1000
 julia> P    = rand(8.0:40,n);
 julia> T    = rand(800.0:2000.0, n);
 julia> out  = multi_point_minimization(P,T, DAT, test=test);
+julia> Finalize_MAGEMin(DAT)
 ```
 By default, this will show a progressbar (which you can deactivate with the `progressbar=false` option).
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ By default, this will show a progressbar (which you can deactivate with the `pro
 
 You can also specify a custom bulk rock for all points (see above), or a custom bulk rock for every point.
 
+
+
 ### Running it in parallel
 Julia can be run in parallel using multi-threading. To take advantage of this, you need to start julia from the terminal with:
 ```bash
@@ -115,7 +117,7 @@ $julia -t auto
 ```
 which will automatically use all threads on your machine. Alternatively, use `julia -t 4` to start it on 4 threads.
 If you are interested to see what you can do on your machine, type:
-```
+```julia
 julia> versioninfo()
 Julia Version 1.9.0
 Commit 8e630552924 (2023-05-07 11:25 UTC)

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -46,7 +46,7 @@ function Initialize_MAGEMin(db = "ig"; verbose = true)
         list_splx_data[id] = splx_data
     end
 
-    return DataBase_DATA(db, list_gv, list_z_b, list_DB, list_splx_data)
+    return MAGEMin_Data(db, list_gv, list_z_b, list_DB, list_splx_data)
 end
 
 
@@ -195,7 +195,7 @@ end
 
 
 """
-    bulk_rock = use_predefined_bulk_rock(gv, test=-1)
+    bulk_rock = use_predefined_bulk_rock(gv, test=-1, db="ig")
 
 Returns the pre-defined bulk rock composition of a given test
 """
@@ -215,6 +215,19 @@ function use_predefined_bulk_rock(gv, test=0, db="ig")
 
     return gv
 end
+
+"""
+    DAT = use_predefined_bulk_rock(DAT::MAGEMin_Data, test=0)
+Returns the pre-defined bulk rock composition of a given test
+"""
+function use_predefined_bulk_rock(DAT::MAGEMin_Data, test=0)
+    nt = Threads.nthreads()
+    for id in 1:nt
+        DAT.gv[id] =  use_predefined_bulk_rock(DAT.gv[id], test, DAT.db)
+    end
+    return DAT
+end
+
 
 function define_bulk_rock(gv, bulk_in, bulk_in_ox, sys_in,db)
 
@@ -362,7 +375,7 @@ julia> finalize_MAGEMin(gv,DB)
 ```
 
 """
-function point_wise_minimization(P::Float64,T::Float64, gv, z_b, DB, splx_data, sys_in::String="mol")
+function point_wise_minimization(P::Float64,T::Float64, gv, z_b, DB, splx_data)
     
     input_data      =   LibMAGEMin.io_data();                           # zero (not used actually)
 
@@ -401,7 +414,11 @@ function point_wise_minimization(P::Float64,T::Float64, gv, z_b, DB, splx_data, 
     return out
 end
 
-point_wise_minimization(P::Number,T::Number, gv, z_b, DB, splx_data, sys_in::String="mol") = point_wise_minimization(Float64(P),Float64(T), gv, z_b, DB, splx_data, sys_in)
+point_wise_minimization(P::Number,T::Number, gv, z_b, DB, splx_data) = point_wise_minimization(Float64(P),Float64(T), gv, z_b, DB, splx_data)
+
+
+point_wise_minimization(P::Number,T::Number, DAT::MAGEMin_Data) = point_wise_minimization(P,T, DAT.gv[1], DAT.z_b[1], DAT.DB[1], DAT.splx_data[1]) 
+
 
 
 """

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -21,11 +21,12 @@ struct MAGEMin_Data{TypeGV, TypeZB, TypeDB, TypeSplxData}
 end
 
 """
-    Dat = Initialize_MAGEMin(db = "ig"; verbose = true)
+    Dat = Initialize_MAGEMin(db = "ig"; verbose::Union{Bool, Int64} = true)
 
 This initialize the MAGEMin databases on every thread, which has to be done once per simulation, or when you change the database.
+You can surpress all output with `verbose=false`. `verbose=true` will give a brief summary of the result, whereas `verbose=1` will give more details about the computations.
 """
-function Initialize_MAGEMin(db = "ig"; verbose = true)
+function Initialize_MAGEMin(db = "ig"; verbose::Union{Bool, Int64} = true)
     gv, z_b, DB, splx_data = init_MAGEMin(db);
 
     nt = Threads.nthreads()
@@ -149,7 +150,7 @@ julia> out = multi_point_minimization(P, T, DAT, test=0)
 julia> Finalize_MAGEMin(DAT)
 ```
 
-Example 2 - Specify constant bulk rock composition
+Example 2 - Specify constant bulk rock composition for all points:
 ===
 ```julia
 julia> DAT = Initialize_MAGEMin("ig", verbose=false);
@@ -231,7 +232,7 @@ function multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMi
 
         # compute a new point using a ccall
         out = point_wise_minimization(P[i], T[i], gv, z_b, DB, splx_data)
-        Out_PT[i] = out
+        Out_PT[i] = deepcopy(out)  
     end
 
     return Out_PT

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -149,6 +149,21 @@ julia> out = multi_point_minimization(P, T, DAT, test=0)
 julia> Finalize_MAGEMin(DAT)
 ```
 
+Example 2 - Specify constant bulk rock composition
+===
+```julia
+julia> DAT = Initialize_MAGEMin("ig", verbose=false);
+julia> n = 10
+julia> P = fill(10.0,n)
+julia> T = fill(1100.0,n)
+julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
+julia> X = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
+julia> sys_in = "wt"    
+julia> out = multi_point_minimization(P, T, DAT, X=X, Xoxides=Xoxides, sys_in=sys_in)
+julia> Finalize_MAGEMin(DAT)
+```
+
+
 """
 function multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMin_db::MAGEMin_Data;  
     test=0, # if using a build-in test case
@@ -172,7 +187,7 @@ function multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMi
 
             # Set the bulk rock composition for all points
             for i in 1:Threads.nthreads()
-                MAGEMin_db.gv[i] = define_bulk_rock(MAGEMin_db.gv[i], X, Xoxides, sys_in, MAGEMin_db.DB[i]);
+                MAGEMin_db.gv[i] = define_bulk_rock(MAGEMin_db.gv[i], X, Xoxides, sys_in, MAGEMin_db.db);
             end
             CompositionType = 1;    # specified bulk composition for all points
         else

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -26,7 +26,7 @@ end
 
 Initializes MAGEMin on one or more threads, for the database `db`. You can surpress all output with `verbose=false`. `verbose=true` will give a brief summary of the result, whereas `verbose=1` will give more details about the computations.
 """
-function Initialize_MAGEMin(db = "ig"; verbose::Union{Bool, Int64} = true)
+function Initialize_MAGEMin(db = "ig"; verbose::Union{Int64,Bool} = 0)
     gv, z_b, DB, splx_data = init_MAGEMin(db);
 
     nt = Threads.nthreads()
@@ -35,12 +35,17 @@ function Initialize_MAGEMin(db = "ig"; verbose::Union{Bool, Int64} = true)
     list_DB = Vector{typeof(DB)}(undef, nt)
     list_splx_data = Vector{typeof(splx_data)}(undef, nt)
 
+    if isa(verbose,Bool)
+        if verbose
+            verbose=0
+        else
+            verbose=-1
+        end
+    end
+
     for id in 1:nt
         gv, z_b, DB, splx_data = init_MAGEMin(db)
-        if !verbose
-            # deactivate verbose output such as printing the result of each `pointwise_miminimzation`
-            gv.verbose = -1
-        end
+        gv.verbose = verbose
         list_gv[id] = gv
         list_z_b[id] = z_b
         list_DB[id] = DB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,21 +62,18 @@ finalize_MAGEMin(gv,DB)
     Finalize_MAGEMin(DAT)
 end
 
-
 @testset "specify bulk rock" begin
+    
+    DAT = Initialize_MAGEMin("ig", verbose=false);
+    n   = 1
+    P,T = fill(10.0,n),fill(1100.0,n)
 
-    db          = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
-    gv, z_b, DB, splx_data      = init_MAGEMin(db);
-    bulk_in_ox = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
-    bulk_in    = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
-    sys_in     = "wt"
-    gv         = define_bulk_rock(gv, bulk_in, bulk_in_ox, sys_in, db);
-    P,T        = 10.0, 1100.0;
-    gv.verbose = -1;        # switch off any verbose
-    out        = point_wise_minimization(P,T, gv, z_b, DB, splx_data)
-    finalize_MAGEMin(gv,DB)
-
-    @test abs(out.G_system + 907.2788704076264)/abs(907.2788704076264) < 2e-4
+    Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
+    X = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
+    sys_in = "wt"    
+    out = multi_point_minimization(P, T, DAT, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    Finalize_MAGEMin(DAT)
+    @test abs(out[end].G_system + 907.2788704076264)/abs(907.2788704076264) < 2e-4
 end
 
 @testset "convert bulk rock" begin
@@ -94,20 +91,15 @@ end
     @test bulk_rock ≈ [76.19220995201881, 8.870954242440064, 2.0746602851534823, 2.8217776479950456, 4.610760310300608, 1.8212574300716888, 2.5559196842000387, 0.6583148666016386, 0.3292810992118903, 0.06486448200674054, 0.0]
 end
 
-
 @testset "test Seismic velocities & modulus" begin
     # Call optimization routine for given P & T & bulk_rock
-    db          = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
-    gv, z_b, DB, splx_data      = init_MAGEMin(db);
+    DAT         = Initialize_MAGEMin("ig", verbose=false);
     test        = 0;
-    sys_in      = "mol"     #default is mol, if wt is provided conversion will be done internally (MAGEMin works on mol basis)
-
-    gv          = use_predefined_bulk_rock(gv, test, db)
+    DAT         = use_predefined_bulk_rock(DAT, test)
     P           = 8.0
     T           = 1200.0
-    gv.verbose  = -1        # switch off any verbose
-    out         = point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in)
-    
+    out         = point_wise_minimization(P,T, DAT)
+
     tol = 5e-2;
     @test abs(out.bulkMod - 95.35222421341481           < tol)
     @test abs(out.shearMod - 29.907907390690557         < tol)
@@ -119,9 +111,8 @@ end
     @test abs(out.bulkModulus_S - 95.74343528580735     < tol)
     @test abs(out.shearModulus_S - 59.4665150508297     < tol)
 
-    finalize_MAGEMin(gv,DB)
+    Finalize_MAGEMin(DAT)
 end
-
 
 # Stores data of tests
 mutable struct outP{ _T  } 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,19 +9,18 @@ end
 using MAGEMin_C         # load MAGEMin (needs to be loaded from main directory to pick up correct library in case it is locally compiled)
 
 # Initialize database 
-db          = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
-gv, z_b, DB, splx_data      = init_MAGEMin(db);
+db          =   "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
+DAT         =   Initialize_MAGEMin(db, verbose=true);
 
-
-sys_in      = "mol"     #default is mol, if wt is provided conversion will be done internally (MAGEMin works on mol basis)
-test        = 0         #KLB1
-gv          = use_predefined_bulk_rock(gv, test, db);
+sys_in      =   "mol"     #default is mol, if wt is provided conversion will be done internally (MAGEMin works on mol basis)
+test        =   0         #KLB1
+DAT         =   use_predefined_bulk_rock(DAT, test);
 
 # Call optimization routine for given P & T & bulk_rock
-P           = 8.0
-T           = 800.0
-gv.verbose  = -1        # switch off any verbose
-out         = point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in);
+P           =   8.0
+T           =   800.0
+out         =   point_wise_minimization(P,T, DAT);
+
 @show out
 
 @test out.G_system ≈ -797.7491824683576
@@ -58,7 +57,7 @@ finalize_MAGEMin(gv,DB)
     gv         = define_bulk_rock(gv, bulk_in, bulk_in_ox, sys_in, db);
     P,T        = 10.0, 1100.0;
     gv.verbose = -1;        # switch off any verbose
-    out        = point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in)
+    out        = point_wise_minimization(P,T, gv, z_b, DB, splx_data)
     finalize_MAGEMin(gv,DB)
 
     @test abs(out.G_system + 907.2788704076264)/abs(907.2788704076264) < 2e-4


### PR DESCRIPTION
This PR brings multi-threading support to `MAGEMin_C` and simplifies running it for multiple points for cases where we have variable chemistry (thanks to @ranocha).

Simple example:
```Julia
julia> using MAGEMin_C
julia> db   = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
julia> DAT  = Initialize_MAGEMin(db, verbose=false);
julia> test = 0         #KLB1
julia> n    = 1000 
julia> P    = rand(8.0:40,n);
julia> T    = rand(800.0:2000.0, n);
julia> out  = multi_point_minimization(P,T, DAT, test=test);
```

Example with custom chemistry:
```Julia
julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
julia> X = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
julia> sys_in = "wt" 
julia> out = multi_point_minimization(P, T, DAT, X=X, Xoxides=Xoxides, sys_in=sys_in)
```

Finalise the calculations with:
```Julia
julia> Finalize_MAGEMin(DAT)
```