### PR TITLE
generalize libname setting in init message

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.3.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MAGEMin_jll = "763ebaa8-b0d2-5f6b-90ef-4fc23b5db1c4"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/gen/magemin_library.jl
+++ b/gen/magemin_library.jl
@@ -5,6 +5,8 @@ export MAGEMin_jll
 
 using CEnum
 
+using Libdl: dlext
+
 #
 # START OF PROLOGUE
 #
@@ -13,12 +15,14 @@ const HASH_JEN = 0;
 
 
 function __init__()
-    if isfile("libMAGEMin.dylib")
-        global libMAGEMin = joinpath(pwd(),"libMAGEMin.dylib")
-        println("Using locally compiled version of libMAGEMin.dylib")
+    libname = "libMAGEMin." * dlext
+    if isfile(libname)
+        global libMAGEMin = joinpath(pwd(), libname)
+        println("Using locally compiled version of $(libname)")
     else
         global libMAGEMin = MAGEMin_jll.libMAGEMin
-        println("Using libMAGEMin.dylib from MAGEMin_jll")
+        libname = basename(libMAGEMin)
+        println("Using $(libname) from MAGEMin_jll")
     end
 end
 
@@ -2117,7 +2121,7 @@ end
 
 
 
-function Base.convert(::Type{SS_data}, a::stb_SS_phases) 
+function Base.convert(::Type{SS_data}, a::stb_SS_phases)
     return SS_data(a.f, a.G, a.deltaG, a.V, a.alpha, a.entropy, a.enthalpy, a.cp, a.rho, a.bulkMod, a.shearMod, a.Vp, a.Vs,
                                     unsafe_wrap( Vector{Cdouble},        a.Comp,             a.nOx),
                                     unsafe_wrap( Vector{Cdouble},        a.Comp_wt,             a.nOx),
@@ -2148,7 +2152,7 @@ struct PP_data
     Comp_wt::Vector{Cdouble}
 end
 
-function Base.convert(::Type{PP_data}, a::stb_PP_phases) 
+function Base.convert(::Type{PP_data}, a::stb_PP_phases)
     return PP_data(a.f, a.G, a.deltaG, a.V, a.alpha, a.entropy, a.enthalpy, a.cp, a.rho, a.bulkMod, a.shearMod, a.Vp, a.Vs,
                     unsafe_wrap(Vector{Cdouble},a.Comp, a.nOx),
                     unsafe_wrap(Vector{Cdouble},a.Comp_wt, a.nOx))


### PR DESCRIPTION
I noticed that the message when loading the package was specific to macOS. I generalized it to other systems.