### PR TITLE
run CI on LTS and latest stable Julia version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.8'
-          - 'nightly'
+          - '1'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
I changed the Julia version v1.8 to just v1 so that CI runs also on the latest stable release. I also removed nightly tests since they may fail and should be caught by PkgEval runs of Julia - we shouldn't need to worry about them.