### PR TITLE
Allow @view array for compositions on single point

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
           - '1.6'
           - '1.9'
           - '1.10'
-          - 'nighthly'
+          - 'nightly'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,9 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1.9'
           - '1.10'
+          - 'nighthly'
           - '1'
         os:
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ julia> P,T     = 10.0, 1100.0
 julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
 julia> X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
 julia> sys_in  = "wt"
-julia> out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+julia> out     = single_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
 Pressure          : 10.0      [kbar]
 Temperature       : 1100.0    [Celsius]
-     Stable phase | Fraction (mol 1 atom basis) 
-              liq   0.73698 
-              cpx   0.17241 
-             pl4T   0.04846 
-     Stable phase | Fraction (wt fraction) 
-              liq   0.70765 
-              cpx   0.18894 
-             pl4T   0.05083 
+     Stable phase | Fraction (mol 1 atom basis)
+              liq   0.73698
+              cpx   0.17241
+             pl4T   0.04846
+     Stable phase | Fraction (wt fraction)
+              liq   0.70765
+              cpx   0.18894
+             pl4T   0.05083
 Gibbs free energy : -907.392253  (22 iterations; 62.25 ms)
 Oxygen fugacity          : 3.400537515666476e-9
 ```
@@ -125,4 +125,4 @@ Platform Info:
   LLVM: libLLVM-14.0.6 (ORCJIT, apple-m1)
   Threads: 8 on 8 virtual cores
 ```
-The function `multi_point_minimization` will automatically utilize parallelization if you run it on >1 threads.
+The function `multi_point_minimization` will automatically use parallelization if you run it on >1 threads.

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -145,10 +145,10 @@ end
 
 
 """
-    Out_PT = multi_point_minimization(P:Vector{_T}, T::Vector, MAGEMin_db::MAGEMin_Data; sys_in="mol", test=0, X::Union{Nothing, Vector, Vector{Vector}}=nothing, progressbar=true)
+    Out_PT = multi_point_minimization(P::T1, T::T1, MAGEMin_db::MAGEMin_Data, X::T2=nothing; test = 0, Xoxides = Vector{String}, sys_in::String = "mol", progressbar = true) where {T1 <: Vector{Float64}, T2 <: VecOrMat}
 
 Perform (parallel) MAGEMin calculations for a range of points as a function of pressure `P`, temperature `T` and/or composition `X`. The database `MAGEMin_db` must be initialised before calling the routine.
-The bulk-rock composition can either be set to be one of the pre-defined build-in test cases, or can be specified specifically by passing `X`, `Xodides` and `sys_in` (that specifies whether the input is in "mol" or "wt").
+The bulk-rock composition can either be set to be one of the pre-defined build-in test cases, or can be specified specifically by passing `X`, `Xoxides` and `sys_in` (that specifies whether the input is in "mol" or "wt").
 
 Below a few examples:
 
@@ -173,7 +173,7 @@ julia> T = fill(1100.0,n)
 julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
 julia> X = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
 julia> sys_in = "wt"
-julia> out = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+julia> out = multi_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
 julia> Finalize_MAGEMin(data)
 ```
 
@@ -188,7 +188,7 @@ julia> X1 = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0]
 julia> X2 = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
 julia> X = [X1,X2]
 julia> sys_in = "wt"
-julia> out = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+julia> out = multi_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
 julia> Finalize_MAGEMin(data)
 ```
 
@@ -196,12 +196,12 @@ Activating multithreading on julia
 ===
 
 To take advantage of multithreading, you need to start julia from the terminal with:
-```julia
-\$julia -t auto
+```bash
+\$ julia -t auto
 ```
 which will automatically use all threads on your machine. Alternatively, use `julia -t 4` to start it on 4 threads.
 If you are interested to see what you can do on your machine type:
-```
+```julia
 julia> versioninfo()
 ```
 

--- a/test/gen_tests.jl
+++ b/test/gen_tests.jl
@@ -1,13 +1,13 @@
-# This script helps to generate a list of points for testing MAGEMin using reference built-in 
-bulk-rock compositions
+# This script helps to generate a list of points for testing MAGEMin using reference built-in
+# bulk-rock compositions
 
-cur_dir = pwd();    
+cur_dir = pwd();
 if  cur_dir[end-3:end]=="test"
     cd("../")           # change to main directory if we are in /test
 end
 using MAGEMin_C
 
-# Initialize database 
+# Initialize database
 db          = "mp"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
 gv, z_b, DB, splx_data      = init_MAGEMin(db);
 
@@ -16,9 +16,9 @@ sys_in      = "mol"     #default is mol, if wt is provided conversion will be do
 test        = 0         #KLB1
 gv          = use_predefined_bulk_rock(gv, test, db);
 
-mutable struct outP{ _T  } 
+mutable struct outP{ _T  }
     P           ::  _T
-    T           ::  _T 
+    T           ::  _T
     test        ::  Int64
 
     G           ::  _T

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -78,7 +78,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
 
     @test abs(out.G_system + 917.008526)/abs(917.008526) < 2e-4
 
@@ -91,10 +91,30 @@ end
     X2      = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     X       = [X1,X2]
     sys_in  = "wt"
-    out     = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = multi_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
 
     @test out[1].G_system ≈ -917.0085258258146 rtol=2e-4
     @test out[2].G_system ≈ -912.7754865001111 rtol=2e-4
+
+    Finalize_MAGEMin(data)
+end
+
+@testset "view array composition" begin
+
+    data    = Initialize_MAGEMin("ig", verbose=false);
+
+    # One bulk rock for all points
+    P,T     = 10.0, 1100.0
+    Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
+    X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
+    sys_in  = "wt"
+
+    X = [[1.0], X]
+    X_view = @view X[2,:]
+
+    out     = single_point_minimization(P, T, data, X_view, Xoxides=Xoxides, sys_in=sys_in)
+
+    @test abs(out.G_system + 917.008526)/abs(917.008526) < 2e-4
 
     Finalize_MAGEMin(data)
 end
@@ -236,4 +256,5 @@ println("Testing points from the reference diagrams:")
         include("test_diagram_test0_mp.jl")
         TestPoints(list, data)
     end
-    Finalize_MAGEMin(data)end
+    Finalize_MAGEMin(data)
+end


### PR DESCRIPTION
Hi,

When working on my projects, I often create arrays containing vectors of composition. In this case, I like to use `@view` array to prevent allocations when I am calling a single point minimisation. Currently, this is not supported by `single_point_minimization` because it only accepts Vector{Float64}.

This PR adds support for AbstractVector{Float64} to be able to use view arrays but also other type of arrays (I didn't go too wild on the multiple dispatch because I don't know how the C code works behind the hood).

So now, this kind of code is working:

```
    data    = Initialize_MAGEMin("ig", verbose=false);

    # One bulk rock for all points
    P,T     = 10.0, 1100.0
    Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
    X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
    sys_in  = "wt"

    X = [[1.0], X]
    X_view = @view X[2,:]

    out     = single_point_minimization(P, T, data, X_view, Xoxides=Xoxides, sys_in=sys_in)

```

The only drawback is that it is a breaking PR because I had to change the argument X to be from a keyword argument to a position argument to use multiple dispatch.

So the function `single_point_minimization` is now called:

```
single_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
```

Compared to 

```
single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
```

before. EDIT Same for `multi_point_minimization`.

I've also added a test for testing view.

Tell me what you think about it.