### PR TITLE
Correct breaking changes from new version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.7'
           - '1.9'
           - 'nightly'
           - '1.10'

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ julia> out  = point_wise_minimization(P,T, data);
  Mode  :  0.24229  0.58808  0.14165  0.02798
 ```
 
-> [!WARNING]
-> Since Version 1.3.6, the functions `point_wise_minimization` and `multi_point_minimization` are deprecated. Use `single_point_minim` and `multi_point_minim` instead.
-
 
 ### Example 2 - custom composition
 And here a case in which you specify your own bulk rock composition.
@@ -60,7 +57,7 @@ julia> P,T     = 10.0, 1100.0
 julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
 julia> X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
 julia> sys_in  = "wt"
-julia> out     = single_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
+julia> out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
 Pressure          : 10.0      [kbar]
 Temperature       : 1100.0    [Celsius]
      Stable phase | Fraction (mol fraction)
@@ -101,7 +98,7 @@ julia> test = 0         #KLB1
 julia> n    = 1000
 julia> P    = rand(8.0:40,n);
 julia> T    = rand(800.0:2000.0, n);
-julia> out  = multi_point_minim(P,T, data, test=test);
+julia> out  = multi_point_minimization(P,T, data, test=test);
 julia> Finalize_MAGEMin(data)
 ```
 By default, this will show a progressbar (which you can deactivate with the `progressbar=false` option).
@@ -127,4 +124,4 @@ Platform Info:
   LLVM: libLLVM-14.0.6 (ORCJIT, apple-m1)
   Threads: 8 on 8 virtual cores
 ```
-The function `multi_point_minim` will automatically utilize parallelization if you run it on >1 threads.
+The function `multi_point_minimization` will automatically utilize parallelization if you run it on >1 threads.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ julia> out  = point_wise_minimization(P,T, data);
  Mode  :  0.24229  0.58808  0.14165  0.02798
 ```
 
+> [!WARNING]
+> Since Version 1.3.6, the functions `point_wise_minimization` and `multi_point_minimization` are deprecated. Use `single_point_minim` and `multi_point_minim` instead.
+
+
 ### Example 2 - custom composition
 And here a case in which you specify your own bulk rock composition.
 ```julia
@@ -56,17 +60,17 @@ julia> P,T     = 10.0, 1100.0
 julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
 julia> X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
 julia> sys_in  = "wt"
-julia> out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+julia> out     = single_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
 Pressure          : 10.0      [kbar]
 Temperature       : 1100.0    [Celsius]
-     Stable phase | Fraction (mol 1 atom basis) 
-              liq   0.73698 
-              cpx   0.17241 
-             pl4T   0.04846 
-     Stable phase | Fraction (wt fraction) 
-              liq   0.70765 
-              cpx   0.18894 
-             pl4T   0.05083 
+     Stable phase | Fraction (mol fraction)
+              liq   0.73698
+              cpx   0.17241
+             pl4T   0.04846
+     Stable phase | Fraction (wt fraction)
+              liq   0.70765
+              cpx   0.18894
+             pl4T   0.05083
 Gibbs free energy : -907.392253  (22 iterations; 62.25 ms)
 Oxygen fugacity          : 3.400537515666476e-9
 ```
@@ -97,14 +101,12 @@ julia> test = 0         #KLB1
 julia> n    = 1000
 julia> P    = rand(8.0:40,n);
 julia> T    = rand(800.0:2000.0, n);
-julia> out  = multi_point_minimization(P,T, data, test=test);
+julia> out  = multi_point_minim(P,T, data, test=test);
 julia> Finalize_MAGEMin(data)
 ```
 By default, this will show a progressbar (which you can deactivate with the `progressbar=false` option).
 
 You can also specify a custom bulk rock for all points (see above), or a custom bulk rock for every point.
-
-
 
 ### Running it in parallel
 Julia can be run in parallel using multi-threading. To take advantage of this, you need to start julia from the terminal with:
@@ -125,4 +127,4 @@ Platform Info:
   LLVM: libLLVM-14.0.6 (ORCJIT, apple-m1)
   Threads: 8 on 8 virtual cores
 ```
-The function `multi_point_minimization` will automatically utilize parallelization if you run it on >1 threads.
+The function `multi_point_minim` will automatically utilize parallelization if you run it on >1 threads.

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -26,7 +26,7 @@ end
 """
 Holds the MAGEMin databases & required structures for every thread
 """
-mutable struct W_Data{T2,T2,M1}
+mutable struct W_Data
     SS_id   :: Vector{Int64}
     SS_len  :: Vector{Int64}
     Ws      :: Vector{Matrix{Float64}}

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -164,18 +164,18 @@ end
 
 
 # wrapper for single point minimization
-function single_point_minim(     P           ::  T1,
-                                 T           ::  T1,
-                                 MAGEMin_db  ::  MAGEMin_Data,
-                                 X           ::  T2                              = nothing;
-                                 test        ::  Int64                           = 0, # if using a build-in test case,
-                                 B           ::  Union{Nothing, T1, Vector{T1}}  = nothing,
-                                 W           ::  Union{Nothing, W_Data}          = nothing,
-                                 Xoxides     = Vector{String},
-                                 sys_in      = "mol",
-                                 progressbar = true        # show a progress bar or not?
+function single_point_minimization(     P           ::  T1,
+                                        T           ::  T1,
+                                        MAGEMin_db  ::  MAGEMin_Data;
+                                        test        ::  Int64                           = 0, # if using a build-in test case,
+                                        X           ::  VecOrMat                        = nothing,
+                                        B           ::  Union{Nothing, T1, Vector{T1}}  = nothing,
+                                        W           ::  Union{Nothing, W_Data}          = nothing,
+                                        Xoxides     = Vector{String},
+                                        sys_in      = "mol",
+                                        progressbar = true        # show a progress bar or not?
 
-                                 ) where {T1 <: Float64, T2 <: VecOrMat}
+                                    ) where {T1 <: Float64}
 
     P   = [P];
     T   = [T];
@@ -183,30 +183,23 @@ function single_point_minim(     P           ::  T1,
         X = [X]
     end
 
-    Out_PT     =   multi_point_minim(    P,
+    Out_PT     =   multi_point_minimization(    P,
                                          T,
                                          MAGEMin_db,
-                                         X,
                                          test        =   test,
+                                         X           =   X,
                                          B           =   B,
                                          W           =   W,
                                          Xoxides     =   Xoxides,
                                          sys_in      =   sys_in,
-                                         progressbar =   progressbar     );
+                                         progressbar =   progressbar);
 
     return Out_PT[1]
 end
 
-# The old API is still supported, but deprecated and implemented using the old one
-Base.@deprecate single_point_minimization(P::Float64, T::Float64, MAGEMin_db::MAGEMin_Data; test::Int64 = 0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}} = nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol", progressbar = true) where _T <: Float64 single_point_minim(P,T,MAGEMin_db,X;test=test, B=B,Xoxides=Xoxides,sys_in=sys_in, progressbar = progressbar)
-
-# function 
-#     Base.depwarn("`single_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `single_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :single_point_minimization)
-    
-# end
 
 """
-Out_PT =multi_point_minim(P::Vector{T1}, T::Vector{T1}, MAGEMin_db::MAGEMin_Data, X::T2=nothing; test=0, caseB::Union{Nothing, T1, Vector{T1}} = nothing, Xoxides= Vector{String}, sys_in= "mol", progressbar = true) where {T1 <: Float64, T2 <: VecOrMat}
+Out_PT =multi_point_minimization(P::Vector{T1}, T::Vector{T1}, MAGEMin_db::MAGEMin_Data, X::T2=nothing; test=0, caseB::Union{Nothing, T1, Vector{T1}} = nothing, Xoxides= Vector{String}, sys_in= "mol", progressbar = true) where {T1 <: Float64, T2 <: VecOrMat}
 
 Perform (parallel) MAGEMin calculations for a range of points as a function of pressure `P`, temperature `T` and/or composition `X`. The database `MAGEMin_db` must be initialised before calling the routine.
 The bulk-rock composition can either be set to be one of the pre-defined build-in test cases, or can be specified specifically by passing `X`, `Xodides` and `sys_in` (that specifies whether the input is in "mol" or "wt").
@@ -220,7 +213,7 @@ julia> data = Initialize_MAGEMin("ig", verbose=false);
 julia> n = 10
 julia> P = rand(8:40.0,n)
 julia> T = rand(800:1500.0,n)
-julia> out = multi_point_minim(P, T, data, test=0)
+julia> out = multi_point_minimization(P, T, data, test=0)
 julia> Finalize_MAGEMin(data)
 ```
 
@@ -234,7 +227,7 @@ julia> T = fill(1100.0,n)
 julia> Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
 julia> X = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
 julia> sys_in = "wt"
-julia> out = multi_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
+julia> out = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
 julia> Finalize_MAGEMin(data)
 ```
 
@@ -249,7 +242,7 @@ julia> X1 = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0]
 julia> X2 = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
 julia> X = [X1,X2]
 julia> sys_in = "wt"
-julia> out = multi_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
+julia> out = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
 julia> Finalize_MAGEMin(data)
 ```
 
@@ -267,17 +260,17 @@ julia> versioninfo()
 ```
 
 """
-function multi_point_minim(  P           ::  Vector{T1},
-                             T           ::  Vector{T1},
-                             MAGEMin_db  ::  MAGEMin_Data,
-                             X           ::  T2=nothing;
-                             test        ::  Int64                           = 0, # if using a build-in test case,
-                             B           ::  Union{Nothing, T1, Vector{T1}}  = nothing,
-                             W           ::  Union{Nothing, W_Data}          = nothing,
-                             Xoxides     = Vector{String},
-                             sys_in      = "mol",
-                             progressbar = true        # show a progress bar or not?
-                             ) where {T1 <: Float64, T2 <: VecOrMat}
+function multi_point_minimization(  P           ::  Vector{T1},
+                                    T           ::  Vector{T1},
+                                    MAGEMin_db  ::  MAGEMin_Data;
+                                    test        ::  Int64                           = 0, # if using a build-in test case,
+                                    X           ::  VecOrMat=nothing,
+                                    B           ::  Union{Nothing, T1, Vector{T1}}  = nothing,
+                                    W           ::  Union{Nothing, W_Data}          = nothing,
+                                    Xoxides     = Vector{String},
+                                    sys_in      = "mol",
+                                    progressbar = true        # show a progress bar or not?
+                                    ) where {T1 <: Float64}
 
     # Set the compositional info
     CompositionType::Int64 = 0;
@@ -363,8 +356,6 @@ function multi_point_minim(  P           ::  Vector{T1},
     return Out_PT
 end
 
-
-Base.@deprecate multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMin_db::MAGEMin_Data; test=0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}}=nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol",progressbar = true) where _T <: Float64 multi_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=sys_in,progressbar=progressbar)
 
 """
 bulk_rock = use_predefined_bulk_rock(gv, test=-1, db="ig")

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -11,8 +11,7 @@ const VecOrMat = Union{Nothing, AbstractVector{Float64}, AbstractVector{<:Abstra
 
 export  init_MAGEMin, finalize_MAGEMin, point_wise_minimization, convertBulk4MAGEMin, use_predefined_bulk_rock, define_bulk_rock, create_output,
         print_info, create_gmin_struct, pwm_init, pwm_run,
-        single_point_minim,
-        multi_point_minim, MAGEMin_Data,
+        single_point_minim, multi_point_minim, MAGEMin_Data, W_Data,
         Initialize_MAGEMin, Finalize_MAGEMin, single_point_minimization, multi_point_minimization
 
 
@@ -27,18 +26,26 @@ mutable struct MAGEMin_Data{TypeGV, TypeZB, TypeDB, TypeSplxData}
     splx_data   :: TypeSplxData
 end
 
+"""
+Holds the MAGEMin databases & required structures for every thread
+"""
+mutable struct W_Data{T2,T2,M1}
+    SS_id   :: Vector{Int64}
+    SS_len  :: Vector{Int64}
+    Ws      :: Vector{Matrix{Float64}}
+end
 
 """
     Dat = Initialize_MAGEMin(db = "ig"; verbose::Union{Bool, Int64} = true)
 
-Initializes MAGEMin on one or more threads, for the database `db`. You can supress all output with `verbose=false`. `verbose=true` will give a brief summary of the result, whereas `verbose=1` will give more details about the computations.
+Initializes MAGEMin on one or more threads, for the database `db`. You can surpress all output with `verbose=false`. `verbose=true` will give a brief summary of the result, whereas `verbose=1` will give more details about the computations.
 """
-function Initialize_MAGEMin(db = "ig";  verbose::Union{Int64,Bool}  = 0,
-                                        limitCaOpx::Int64           = 0,
-                                        CaOpxLim::Float64           = 0.0,
-                                        mbCpx::Int64                = 1,
-                                        buffer::String              = "NONE",
-                                        solver::Int64               = 1         )
+function Initialize_MAGEMin(db = "ig";  verbose     ::Union{Int64,Bool} = 0,
+                                        limitCaOpx  ::Int64             = 0,
+                                        CaOpxLim    ::Float64           = 0.0,
+                                        mbCpx       ::Int64             = 1,
+                                        buffer      ::String            = "NONE",
+                                        solver      ::Int64             = 1         )
 
     gv, z_b, DB, splx_data = init_MAGEMin(db;   verbose     = verbose,
                                                 mbCpx       = mbCpx,
@@ -62,7 +69,12 @@ function Initialize_MAGEMin(db = "ig";  verbose::Union{Int64,Bool}  = 0,
     end
 
     for id in 1:nt
-        gv, z_b, DB, splx_data = init_MAGEMin(db; verbose=verbose, mbCpx=mbCpx, limitCaOpx=limitCaOpx, CaOpxLim=CaOpxLim, buffer=buffer, solver=solver)
+        gv, z_b, DB, splx_data = init_MAGEMin(db;   verbose     = verbose,
+                                                    mbCpx       = mbCpx,
+                                                    limitCaOpx  = limitCaOpx,
+                                                    CaOpxLim    = CaOpxLim,
+                                                    buffer      = buffer,
+                                                    solver      = solver    );
 
         list_gv[id]         = gv
         list_z_b[id]        = z_b
@@ -82,12 +94,7 @@ function Finalize_MAGEMin(dat::MAGEMin_Data)
     for id in 1:Threads.nthreads()
 
         LibMAGEMin.FreeDatabases(dat.gv[id], dat.DB[id], dat.z_b[id])
-
-        # These are indeed not freed yet (same with C-code), which should be added for completion
-        # They are rather small structs compared to the others
-        # z_b = dat.z_b[id]
-        # splx_data = dat.splx_data[id]
-
+        # splx_data needs to be freed
      end
      return nothing
 end
@@ -98,7 +105,13 @@ end
 
 Initializes MAGEMin (including setting global options) and loads the Database.
 """
-function  init_MAGEMin(db="ig"; verbose=0, mbCpx=0, limitCaOpx=0, CaOpxLim=1.0, buffer="NONE", solver=1)
+function  init_MAGEMin( db          =  "ig";
+                        verbose     =   0,
+                        mbCpx       =   0,
+                        limitCaOpx  =   0,
+                        CaOpxLim    =   1.0,
+                        buffer      =  "NONE",
+                        solver      =   1           )
 
     z_b         = LibMAGEMin.bulk_infos()
     gv          = LibMAGEMin.global_variables()
@@ -124,18 +137,18 @@ function  init_MAGEMin(db="ig"; verbose=0, mbCpx=0, limitCaOpx=0, CaOpxLim=1.0, 
         print("Database not implemented...\n")
     end
 
-    gv.verbose  = verbose
-    gv.mbCpx    = mbCpx
-    gv.limitCaOpx = limitCaOpx
-    gv.CaOpxLim = CaOpxLim
-    gv.solver   = solver
-    gv.buffer   = pointer(buffer)
+    gv.verbose      = verbose
+    gv.mbCpx        = mbCpx
+    gv.limitCaOpx   = limitCaOpx
+    gv.CaOpxLim     = CaOpxLim
+    gv.solver       = solver
+    gv.buffer       = pointer(buffer)
 
-    gv          = LibMAGEMin.global_variable_init(gv, pointer_from_objref(z_b))
-    DB          = LibMAGEMin.InitializeDatabases(gv, gv.EM_database)
+    gv              = LibMAGEMin.global_variable_init(gv, pointer_from_objref(z_b))
+    DB              = LibMAGEMin.InitializeDatabases(gv, gv.EM_database)
 
-    LibMAGEMin.init_simplex_A( pointer_from_objref(splx_data), gv)
-    LibMAGEMin.init_simplex_B_em( pointer_from_objref(splx_data), gv)
+    LibMAGEMin.init_simplex_A(      pointer_from_objref(splx_data), gv)
+    LibMAGEMin.init_simplex_B_em(   pointer_from_objref(splx_data), gv)
 
     return gv, z_b, DB, splx_data
 end
@@ -151,40 +164,42 @@ end
 
 
 # wrapper for single point minimization
-function single_point_minim(     P::T1,
-                                        T::T1,
-                                        MAGEMin_db::MAGEMin_Data,
-                                        X::T2=nothing;
-                                        test::Int64 = 0, # if using a build-in test case,
-                                        B::Union{Nothing, T1, Vector{T1}} = nothing,
-                                        Xoxides     = Vector{String},
-                                        sys_in      = "mol",
-                                        progressbar = true        # show a progress bar or not?
-                                        ) where {T1 <: Float64, T2 <: VecOrMat}
+function single_point_minim(     P           ::  T1,
+                                 T           ::  T1,
+                                 MAGEMin_db  ::  MAGEMin_Data,
+                                 X           ::  T2                              = nothing;
+                                 test        ::  Int64                           = 0, # if using a build-in test case,
+                                 B           ::  Union{Nothing, T1, Vector{T1}}  = nothing,
+                                 W           ::  Union{Nothing, W_Data}          = nothing,
+                                 Xoxides     = Vector{String},
+                                 sys_in      = "mol",
+                                 progressbar = true        # show a progress bar or not?
 
-    P = [P];
-    T = [T];
+                                 ) where {T1 <: Float64, T2 <: VecOrMat}
+
+    P   = [P];
+    T   = [T];
     if X isa AbstractVector{Float64}
         X = [X]
     end
 
-
-    Out_PT     =   multi_point_minim(P,
-                                            T,
-                                            MAGEMin_db,
-                                            X,
-                                            test=test,
-                                            B=B,
-                                            Xoxides=Xoxides,
-                                            sys_in=sys_in,
-                                            progressbar=progressbar);
+    Out_PT     =   multi_point_minim(    P,
+                                         T,
+                                         MAGEMin_db,
+                                         X,
+                                         test        =   test,
+                                         B           =   B,
+                                         W           =   W,
+                                         Xoxides     =   Xoxides,
+                                         sys_in      =   sys_in,
+                                         progressbar =   progressbar     );
 
     return Out_PT[1]
 end
 
 # The old API is still supported, but deprecated and implemented using the old one
 function single_point_minimization(P::Float64, T::Float64, MAGEMin_db::MAGEMin_Data; test::Int64 = 0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}} = nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol", progressbar = true) where _T <: Float64
-    Base.depwarn("`single_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `single_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :single_point_minimization, force=true)
+    Base.depwarn("`single_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `single_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :single_point_minimization)
     single_point_minim(P,T,MAGEMin_db,X;test=test, B=B,Xoxides=Xoxides,sys_in=sys_in, progressbar = progressbar)
 end
 
@@ -250,16 +265,17 @@ julia> versioninfo()
 ```
 
 """
-function multi_point_minim(  P::Vector{T1},
-                                    T::Vector{T1},
-                                    MAGEMin_db::MAGEMin_Data,
-                                    X::T2=nothing;
-                                    test        = 0, # if using a build-in test case
-                                    B::Union{Nothing, T1, Vector{T1}} = nothing,
-                                    Xoxides     = Vector{String},
-                                    sys_in      = "mol",
-                                    progressbar = true        # show a progress bar or not?
-                                    ) where {T1 <: Float64, T2 <: VecOrMat}
+function multi_point_minim(  P           ::  Vector{T1},
+                             T           ::  Vector{T1},
+                             MAGEMin_db  ::  MAGEMin_Data,
+                             X           ::  T2=nothing;
+                             test        ::  Int64                           = 0, # if using a build-in test case,
+                             B           ::  Union{Nothing, T1, Vector{T1}}  = nothing,
+                             W           ::  Union{Nothing, W_Data}          = nothing,
+                             Xoxides     = Vector{String},
+                             sys_in      = "mol",
+                             progressbar = true        # show a progress bar or not?
+                             ) where {T1 <: Float64, T2 <: VecOrMat}
 
     # Set the compositional info
     CompositionType::Int64 = 0;
@@ -295,17 +311,17 @@ function multi_point_minim(  P::Vector{T1},
     # in some weird way with (libsc, p4est, t8code) - in particular on Linux where
     # we get segfaults. To avoid this, we force serial compilation by calling MAGEMin
     # once before the loop.
-    let id      = 1
-        gv          = MAGEMin_db.gv[id]
-        z_b         = MAGEMin_db.z_b[id]
-        DB          = MAGEMin_db.DB[id]
-        splx_data   = MAGEMin_db.splx_data[id]
-        if isnothing(B)
-            point_wise_minimization(P[1], T[1], gv, z_b, DB, splx_data, sys_in)
-        else
-            point_wise_minimization(P[1], T[1], gv, z_b, DB, splx_data, sys_in; buffer_n = B[1])
-        end
-    end
+    # let id      = 1
+    #     gv          = MAGEMin_db.gv[id]
+    #     z_b         = MAGEMin_db.z_b[id]
+    #     DB          = MAGEMin_db.DB[id]
+    #     splx_data   = MAGEMin_db.splx_data[id]
+    #     if isnothing(B)
+    #         point_wise_minimization(P[1], T[1], gv, z_b, DB, splx_data, sys_in)
+    #     else
+    #         point_wise_minimization(P[1], T[1], gv, z_b, DB, splx_data, sys_in; buffer_n = B[1])
+    #     end
+    # end
 
     # main loop
     if progressbar
@@ -328,9 +344,9 @@ function multi_point_minim(  P::Vector{T1},
 
         # compute a new point using a ccall
         if isnothing(B)
-            out         = point_wise_minimization(P[i], T[i], gv, z_b, DB, splx_data)
+            out     = point_wise_minimization(P[i], T[i], gv, z_b, DB, splx_data)
         else
-            out         = point_wise_minimization(P[i], T[i], gv, z_b, DB, splx_data; buffer_n = B[i])
+            out     = point_wise_minimization(P[i], T[i], gv, z_b, DB, splx_data; buffer_n = B[i], W = W)
         end
         Out_PT[i]   = deepcopy(out)
 
@@ -345,8 +361,8 @@ function multi_point_minim(  P::Vector{T1},
     return Out_PT
 end
 
-function multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMin_db::MAGEMin_Data; test=0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}}=nothing, B=nothing, Xoxides = Vector{String}, sys_in = "mol",progressbar = true) where _T <: Float64
-    Base.depwarn("`multi_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `multi_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :multi_point_minimization, force=true)
+function multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMin_db::MAGEMin_Data; test=0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}}=nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol",progressbar = true) where _T <: Float64
+    Base.depwarn("`multi_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `multi_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :multi_point_minimization)
     multi_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=sys_in,progressbar=progressbar)
 end
 
@@ -499,7 +515,6 @@ function convertBulk4MAGEMin(bulk_in::T1,bulk_in_ox::Vector{String},sys_in::Stri
         c = idNonH2O;
     end
 
-
     id0 = findall(MAGEMin_bulk[c] .== 0.0)
     if ~isempty(id0)
         MAGEMin_bulk[id0] .= 1e-4;
@@ -577,14 +592,11 @@ julia> finalize_MAGEMin(gv,DB)
 ```
 
 """
-function point_wise_minimization(P::Float64,T::Float64, gv, z_b, DB, splx_data; buffer_n = 0.0)
-    gv.buffer_n     = buffer_n
-
-    input_data      =   LibMAGEMin.io_data();                           # zero (not used actually)
-
-    z_b.T           =   T + 273.15    # in K
+function point_wise_minimization(P::Float64,T::Float64, gv, z_b, DB, splx_data; buffer_n = 0.0, W = nothing)
+    gv.buffer_n     =   buffer_n
+    input_data      =   LibMAGEMin.io_data();           # zero (not used actually)
+    z_b.T           =   T + 273.15                      # in K
     z_b.P           =   P
-
     gv.numPoint     = 1; 							    # the number of the current point */
 
     # Perform the point-wise minimization after resetting variables
@@ -624,11 +636,11 @@ end
 
 Performs a point-wise optimization for a given pressure `P` and temperature `T` foir the data specified in the MAGEMin database `MAGEMin_Data` (where also compoition is specified)
 """
-point_wise_minimization(P::Number,T::Number, gv, z_b, DB, splx_data; buffer_n::Float64 = 0.0) = point_wise_minimization(Float64(P),Float64(T), gv, z_b, DB, splx_data; buffer_n)
+point_wise_minimization(P::Number,T::Number, gv, z_b, DB, splx_data; buffer_n::Float64 = 0.0, W::Union{Nothing, W_Data} = nothing) = point_wise_minimization(Float64(P),Float64(T), gv, z_b, DB, splx_data; buffer_n, W)
 
-point_wise_minimization(P::Number,T::Number, gv::LibMAGEMin.global_variables, z_b::LibMAGEMin.bulk_infos, DB::LibMAGEMin.Database, splx_data::LibMAGEMin.simplex_datas, sys_in::String; buffer_n::Float64 = 0.0) = point_wise_minimization(P,T, gv, z_b, DB, splx_data; buffer_n)
+point_wise_minimization(P::Number,T::Number, gv::LibMAGEMin.global_variables, z_b::LibMAGEMin.bulk_infos, DB::LibMAGEMin.Database, splx_data::LibMAGEMin.simplex_datas, sys_in::String; buffer_n::Float64 = 0.0, W::Union{Nothing, W_Data} = nothing) = point_wise_minimization(P,T, gv, z_b, DB, splx_data; buffer_n, W)
 
-point_wise_minimization(P::Number,T::Number, data::MAGEMin_Data; buffer_n::Float64 = 0.0) = point_wise_minimization(P,T, data.gv[1], data.z_b[1], data.DB[1], data.splx_data[1]; buffer_n)
+point_wise_minimization(P::Number,T::Number, data::MAGEMin_Data; buffer_n::Float64 = 0.0, W::Union{Nothing, W_Data} = nothing) = point_wise_minimization(P,T, data.gv[1], data.z_b[1], data.DB[1], data.splx_data[1]; buffer_n, W)
 
 
 """

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -195,10 +195,10 @@ end
 
 
 """
-Out_PT =multi_point_minimization(P::Vector{T1}, T::Vector{T1}, MAGEMin_db::MAGEMin_Data, X::T2=nothing; test=0, caseB::Union{Nothing, T1, Vector{T1}} = nothing, Xoxides= Vector{String}, sys_in= "mol", progressbar = true) where {T1 <: Float64, T2 <: VecOrMat}
+Out_PT =multi_point_minimization(P::Vector{T1},T::Vector{T1},MAGEMin_db::MAGEMin_Data;test::Int64=0,X::VecOrMat=nothing,B::Union{Nothing, T1, Vector{T1}}=nothing,W::Union{Nothing, W_Data}=nothing,Xoxides=Vector{String},sys_in="mol",progressbar=true) where {T1 <: Float64}
 
 Perform (parallel) MAGEMin calculations for a range of points as a function of pressure `P`, temperature `T` and/or composition `X`. The database `MAGEMin_db` must be initialised before calling the routine.
-The bulk-rock composition can either be set to be one of the pre-defined build-in test cases, or can be specified specifically by passing `X`, `Xodides` and `sys_in` (that specifies whether the input is in "mol" or "wt").
+The bulk-rock composition can either be set to be one of the pre-defined build-in test cases, or can be specified specifically by passing `X`, `Xoxides` and `sys_in` (that specifies whether the input is in "mol" or "wt").
 
 Below a few examples:
 

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -6,13 +6,10 @@ using ProgressMeter
 
 const VecOrMat = Union{Nothing, AbstractVector{Float64}, AbstractVector{<:AbstractVector{Float64}}}
 
-# export  init_MAGEMin, finalize_MAGEMin, point_wise_minimization, convertBulk4MAGEMin, use_predefined_bulk_rock, define_bulk_rock,create_output,
-#         print_info, create_gmin_struct, pwm_init, pwm_run
-
 export  init_MAGEMin, finalize_MAGEMin, point_wise_minimization, convertBulk4MAGEMin, use_predefined_bulk_rock, define_bulk_rock, create_output,
         print_info, create_gmin_struct, pwm_init, pwm_run,
-        single_point_minim, multi_point_minim, MAGEMin_Data, W_Data,
-        Initialize_MAGEMin, Finalize_MAGEMin, single_point_minimization, multi_point_minimization
+        single_point_minimization, multi_point_minimization, MAGEMin_Data, W_Data,
+        Initialize_MAGEMin, Finalize_MAGEMin
 
 
 """
@@ -174,7 +171,6 @@ function single_point_minimization(     P           ::  T1,
                                         Xoxides     = Vector{String},
                                         sys_in      = "mol",
                                         progressbar = true        # show a progress bar or not?
-
                                     ) where {T1 <: Float64}
 
     P   = [P];
@@ -184,15 +180,15 @@ function single_point_minimization(     P           ::  T1,
     end
 
     Out_PT     =   multi_point_minimization(    P,
-                                         T,
-                                         MAGEMin_db,
-                                         test        =   test,
-                                         X           =   X,
-                                         B           =   B,
-                                         W           =   W,
-                                         Xoxides     =   Xoxides,
-                                         sys_in      =   sys_in,
-                                         progressbar =   progressbar);
+                                                T,
+                                                MAGEMin_db,
+                                                test        =   test,
+                                                X           =   X,
+                                                B           =   B,
+                                                W           =   W,
+                                                Xoxides     =   Xoxides,
+                                                sys_in      =   sys_in,
+                                                progressbar =   progressbar);
 
     return Out_PT[1]
 end

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -195,7 +195,7 @@ end
 
 
 """
-Out_PT =multi_point_minimization(P::Vector{T1},T::Vector{T1},MAGEMin_db::MAGEMin_Data;test::Int64=0,X::VecOrMat=nothing,B::Union{Nothing, T1, Vector{T1}}=nothing,W::Union{Nothing, W_Data}=nothing,Xoxides=Vector{String},sys_in="mol",progressbar=true) where {T1 <: Float64}
+Out_PT =multi_point_minimization(P::Vector{T1},T::Vector{T1},MAGEMin_db::MAGEMin_Data;test::Int64=0,X::Union{Nothing, AbstractVector{Float64}, AbstractVector{<:AbstractVector{Float64}}}=nothing,B::Union{Nothing, T1, Vector{T1}}=nothing,W::Union{Nothing, W_Data}=nothing,Xoxides=Vector{String},sys_in="mol",progressbar=true) where {T1 <: Float64}
 
 Perform (parallel) MAGEMin calculations for a range of points as a function of pressure `P`, temperature `T` and/or composition `X`. The database `MAGEMin_db` must be initialised before calling the routine.
 The bulk-rock composition can either be set to be one of the pre-defined build-in test cases, or can be specified specifically by passing `X`, `Xoxides` and `sys_in` (that specifies whether the input is in "mol" or "wt").
@@ -514,9 +514,9 @@ end
 
 
 """
-    point_wise_minimization(P::Float64,T::Float64, gv, z_b, DB, splx_data, sys_in::String="mol")
+    point_wise_minimization(P::Float64,T::Float64, gv, z_b, DB, splx_data; buffer_n = 0.0, W = nothing)
 
-Computes the stable assemblage at `P` [kbar], `T` [C] and for a given bulk rock composition
+Computes the stable assemblage at `P` [kbar], `T` [°C] and for a given bulk rock composition
 
 
 # Example 1

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -31,7 +31,7 @@ end
 """
     Dat = Initialize_MAGEMin(db = "ig"; verbose::Union{Bool, Int64} = true)
 
-Initializes MAGEMin on one or more threads, for the database `db`. You can surpress all output with `verbose=false`. `verbose=true` will give a brief summary of the result, whereas `verbose=1` will give more details about the computations.
+Initializes MAGEMin on one or more threads, for the database `db`. You can supress all output with `verbose=false`. `verbose=true` will give a brief summary of the result, whereas `verbose=1` will give more details about the computations.
 """
 function Initialize_MAGEMin(db = "ig";  verbose::Union{Int64,Bool}  = 0,
                                         limitCaOpx::Int64           = 0,
@@ -531,7 +531,7 @@ julia> T           = 800.0;
 julia> gv.verbose  = -1;        # switch off any verbose
 julia> out         = point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in)
 Pressure          : 8.0      [kbar]
-Temperature       : 800.0    [Celcius]
+Temperature       : 800.0    [Celsius]
      Stable phase | Fraction (mol fraction)
               opx   0.24229
                ol   0.58808
@@ -560,7 +560,7 @@ julia> P,T         = 10.0, 1100.0;
 julia> gv.verbose  = -1;        # switch off any verbose
 julia> out         = point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in)
 Pressure          : 10.0      [kbar]
-Temperature       : 1100.0    [Celcius]
+Temperature       : 1100.0    [Celsius]
      Stable phase | Fraction (mol fraction)
              pl4T   0.01114
               liq   0.74789
@@ -698,7 +698,7 @@ struct gmin_struct{T,I}
     G_system::T             # G of system
     Gamma::Vector{T}        # Gamma
     P_kbar::T               # Pressure in kbar
-    T_C::T                  # Temperature in Celcius
+    T_C::T                  # Temperature in Celsius
 
     # bulk rock composition:
     bulk::Vector{T}
@@ -888,7 +888,7 @@ end
 # Print brief info about pointwise calculation result
 function show(io::IO, g::gmin_struct)
     println(io, "Pressure          : $(g.P_kbar)      [kbar]")
-    println(io, "Temperature       : $(round(g.T_C,digits=4))    [Celcius]")
+    println(io, "Temperature       : $(round(g.T_C,digits=4))    [Celsius]")
 
     println(io, "     Stable phase | Fraction (mol fraction) ")
     for i=1:length(g.ph)

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -198,10 +198,12 @@ function single_point_minim(     P           ::  T1,
 end
 
 # The old API is still supported, but deprecated and implemented using the old one
-function single_point_minimization(P::Float64, T::Float64, MAGEMin_db::MAGEMin_Data; test::Int64 = 0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}} = nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol", progressbar = true) where _T <: Float64
-    Base.depwarn("`single_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `single_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :single_point_minimization)
-    single_point_minim(P,T,MAGEMin_db,X;test=test, B=B,Xoxides=Xoxides,sys_in=sys_in, progressbar = progressbar)
-end
+Base.@deprecate single_point_minimization(P::Float64, T::Float64, MAGEMin_db::MAGEMin_Data; test::Int64 = 0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}} = nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol", progressbar = true) where _T <: Float64 single_point_minim(P,T,MAGEMin_db,X;test=test, B=B,Xoxides=Xoxides,sys_in=sys_in, progressbar = progressbar)
+
+# function 
+#     Base.depwarn("`single_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `single_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :single_point_minimization)
+    
+# end
 
 """
 Out_PT =multi_point_minim(P::Vector{T1}, T::Vector{T1}, MAGEMin_db::MAGEMin_Data, X::T2=nothing; test=0, caseB::Union{Nothing, T1, Vector{T1}} = nothing, Xoxides= Vector{String}, sys_in= "mol", progressbar = true) where {T1 <: Float64, T2 <: VecOrMat}
@@ -361,10 +363,8 @@ function multi_point_minim(  P           ::  Vector{T1},
     return Out_PT
 end
 
-function multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMin_db::MAGEMin_Data; test=0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}}=nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol",progressbar = true) where _T <: Float64
-    Base.depwarn("`multi_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in=\"mol\",progressbar=true)` is deprecated, use `multi_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=\"mol\",progressbar=true)` instead.", :multi_point_minimization)
-    multi_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=sys_in,progressbar=progressbar)
-end
+
+Base.@deprecate multi_point_minimization(P::Vector{Float64}, T::Vector{Float64}, MAGEMin_db::MAGEMin_Data; test=0, X::Union{Nothing, Vector{_T}, Vector{Vector{_T}}}=nothing, B::Union{Nothing, _T, Vector{_T}}=nothing, Xoxides = Vector{String}, sys_in = "mol",progressbar = true) where _T <: Float64 multi_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in=sys_in,progressbar=progressbar)
 
 """
 bulk_rock = use_predefined_bulk_rock(gv, test=-1, db="ig")

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -195,7 +195,7 @@ end
 
 
 """
-Out_PT =multi_point_minimization(P::Vector{T1},T::Vector{T1},MAGEMin_db::MAGEMin_Data;test::Int64=0,X::Union{Nothing, AbstractVector{Float64}, AbstractVector{<:AbstractVector{Float64}}}=nothing,B::Union{Nothing, T1, Vector{T1}}=nothing,W::Union{Nothing, W_Data}=nothing,Xoxides=Vector{String},sys_in="mol",progressbar=true) where {T1 <: Float64}
+Out_PT =multi_point_minimization(P::T2,T::T2,MAGEMin_db::MAGEMin_Data;test::Int64=0,X::Union{Nothing, AbstractVector{Float64}, AbstractVector{<:AbstractVector{Float64}}}=nothing,B::Union{Nothing, T1, Vector{T1}}=nothing,W::Union{Nothing, W_Data}=nothing,Xoxides=Vector{String},sys_in="mol",progressbar=true) where {T1 <: Float64, T2 <: AbstractVector{T1}}
 
 Perform (parallel) MAGEMin calculations for a range of points as a function of pressure `P`, temperature `T` and/or composition `X`. The database `MAGEMin_db` must be initialised before calling the routine.
 The bulk-rock composition can either be set to be one of the pre-defined build-in test cases, or can be specified specifically by passing `X`, `Xoxides` and `sys_in` (that specifies whether the input is in "mol" or "wt").
@@ -256,8 +256,8 @@ julia> versioninfo()
 ```
 
 """
-function multi_point_minimization(  P           ::  Vector{T1},
-                                    T           ::  Vector{T1},
+function multi_point_minimization(  P           ::  T2,
+                                    T           ::  T2,
                                     MAGEMin_db  ::  MAGEMin_Data;
                                     test        ::  Int64                           = 0, # if using a build-in test case,
                                     X           ::  VecOrMat=nothing,
@@ -266,7 +266,7 @@ function multi_point_minimization(  P           ::  Vector{T1},
                                     Xoxides     = Vector{String},
                                     sys_in      = "mol",
                                     progressbar = true        # show a progress bar or not?
-                                    ) where {T1 <: Float64}
+                                    ) where {T1 <: Float64, T2 <: AbstractVector{T1}}
 
     # Set the compositional info
     CompositionType::Int64 = 0;

--- a/julia/install_MAGEMin.jl
+++ b/julia/install_MAGEMin.jl
@@ -32,7 +32,7 @@ end
 
 write_environmental_variables_file()
 
-println("Succesfully downloaded the MAGEMin_jll package")
+println("Successfully downloaded the MAGEMin_jll package")
 println("And installed the environmental_variables.m file in: $(pwd())")
 
 # Show the version number

--- a/test/gen_tests_ig.jl
+++ b/test/gen_tests_ig.jl
@@ -1,4 +1,4 @@
-# This script helps to generate a lsit of points for testing MAGEMin using reference built-in bulk-rock compositions
+# This script helps to generate a list of points for testing MAGEMin using reference built-in bulk-rock compositions
 
 cur_dir = pwd();    
 if  cur_dir[end-3:end]=="test"

--- a/test/gen_tests_mb.jl
+++ b/test/gen_tests_mb.jl
@@ -1,4 +1,4 @@
-# This script helps to generate a lsit of points for testing MAGEMin using reference built-in bulk-rock compositions
+# This script helps to generate a list of points for testing MAGEMin using reference built-in bulk-rock compositions
 
 cur_dir = pwd();    
 if  cur_dir[end-3:end]=="test"

--- a/test/gen_tests_mp.jl
+++ b/test/gen_tests_mp.jl
@@ -1,4 +1,4 @@
-# This script helps to generate a lsit of points for testing MAGEMin using reference built-in bulk-rock compositions
+# This script helps to generate a list of points for testing MAGEMin using reference built-in bulk-rock compositions
 
 cur_dir = pwd();    
 if  cur_dir[end-3:end]=="test"

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -14,7 +14,7 @@ data        =   use_predefined_bulk_rock(data, test);
 # Call optimization routine for given P & T & bulk_rock
 P           =   8.0
 T           =   800.0
-out         =   point_wise_minimization(P,T, data);
+out         =   point_wise_minim(P,T, data);
 
 @show out
 
@@ -36,7 +36,7 @@ gv          =   use_predefined_bulk_rock(gv, test, db);
 gv.verbose=-1
 P           =   8.0
 T           =   800.0
-out         =   point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in);
+out         =   point_wise_minim(P,T, gv, z_b, DB, splx_data, sys_in);
 @test out.G_system ≈ -797.7491828675325
 @test out.ph == ["spn", "cpx",  "opx", "ol"]
 @test all(abs.(out.ph_frac - [0.027985692010022857, 0.14166112328585387, 0.24227821491186913, 0.5880749697922566])  .< 1e-2)
@@ -46,9 +46,9 @@ finalize_MAGEMin(gv,DB,z_b)
     n       =   100;
     P       =   fill(8.0,n)
     T       =   fill(800.0,n)
-    db      =   "ig" 
+    db      =   "ig"
     data    =   Initialize_MAGEMin(db, verbose=false);
-    out     =   multi_point_minimization(P, T, data, test=0);
+    out     =   multi_point_minim(P, T, data, test=0);
     @test out[end].G_system ≈ -797.7491828675325
     @test out[end].ph == ["spn", "cpx",  "opx", "ol"]
     @test all(abs.(out[end].ph_frac - [0.027985692010022857, 0.14166112328585387, 0.24227821491186913, 0.5880749697922566])  .< 1e-2)
@@ -57,16 +57,16 @@ finalize_MAGEMin(gv,DB,z_b)
 end
 
 @testset "specify bulk rock" begin
-    
+
 
     data    = Initialize_MAGEMin("ig", verbose=false);
-    
+
     # One bulk rock for all points
     P,T     = 10.0, 1100.0
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
-    sys_in  = "wt"    
-    out     = single_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
+    sys_in  = "wt"
+    out     = single_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
 
     @test abs(out.G_system + 916.8283889543869)/abs(916.8283889543869) < 2e-4
 
@@ -78,9 +78,9 @@ end
     X1      = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     X2      = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     X       = [X1,X2]
-    sys_in  = "wt"    
-    out     = multi_point_minimization(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
-    
+    sys_in  = "wt"
+    out     = multi_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
+
     @test out[1].G_system ≈ -916.8283889543869 rtol=2e-4
     @test out[2].G_system ≈ -912.5920719174167 rtol=2e-4
 
@@ -100,7 +100,7 @@ end
     X = [[1.0], X]
     X_view = @view X[2,:]
 
-    out     = single_point_minimization(P, T, data, X_view, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minim(P, T, data, X_view, Xoxides=Xoxides, sys_in=sys_in)
 
     @test abs(out.G_system + 916.8283889543869)/abs(916.8283889543869) < 2e-4
 
@@ -130,7 +130,7 @@ end
     data         = use_predefined_bulk_rock(data, test)
     P           = 8.0
     T           = 1200.0
-    out         = point_wise_minimization(P,T, data)
+    out         = point_wise_minim(P,T, data)
 
     tol = 1e-2;
     @test abs(out.bulkMod - 94.98281736576462           < tol)
@@ -148,9 +148,9 @@ end
 end
 
 # Stores data of tests
-mutable struct outP{ _T  } 
+mutable struct outP{ _T  }
     P           ::  _T
-    T           ::  _T 
+    T           ::  _T
     test        ::  Int64
 
     G           ::  _T
@@ -168,7 +168,7 @@ function TestPoints(list, data::MAGEMin_Data)
     P = [ l.P for l in list]
     T = [ l.T for l in list]
     test = [ l.test for l in list]
-    out_vec = multi_point_minimization(P, T, data, test = test[1]);
+    out_vec = multi_point_minim(P, T, data, test = test[1]);
 
     # Check if the points this fit
     for (i,out) in enumerate(out_vec)
@@ -183,16 +183,16 @@ function VerifyPoint(out, list, i)
      # We need to sort the phases (sometimes they are ordered differently)
      ind_sol = sortperm(list.ph)
      ind_out = sortperm(out.ph)
-     
+
      result1 = @test out.G_system  ≈ list.G     rtol=1e-3
      result2 = @test out.ph[ind_out]        == list.ph[ind_sol]
      result3 = @test sort(out.ph_frac) ≈ sort(list.ph_frac) atol=5e-2       # ok, this is really large (needs fixing for test6!)
-     
+
      # print more info about the point if one of the tests above fails
      if isa(result1,Test.Fail) || isa(result2,Test.Fail) || isa(result3,Test.Fail)
          print_error_msg(i,list)
      end
-     
+
      return nothing
 end
 
@@ -204,7 +204,7 @@ println("Testing points from the reference diagrams:")
     println("  Starting KLB-1 peridotite tests")
     db  = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
     data = Initialize_MAGEMin(db, verbose=false);
-   
+
     gv.verbose=-1;
     @testset "IG-DB - KLB-1 peridotite" begin
         include("test_diagram_test0.jl")
@@ -220,7 +220,7 @@ println("Testing points from the reference diagrams:")
         include("test_diagram_test1.jl")
         TestPoints(list, data)
     end
-   
+
     println("  Starting Wet MORB tests")
     db          = "ig"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
     data = Initialize_MAGEMin(db, verbose=false);
@@ -234,7 +234,7 @@ println("Testing points from the reference diagrams:")
     println("  Starting WM Pelite tests")
     db  = "mp"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
     data = Initialize_MAGEMin(db, verbose=false);
-   
+
     gv.verbose=-1;
     @testset "MP-DB - WM Pelite" begin
         include("test_diagram_test0_mp.jl")
@@ -245,7 +245,7 @@ println("Testing points from the reference diagrams:")
     println("  Starting Gt-Migmatite tests")
     db  = "mp"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
     data = Initialize_MAGEMin(db, verbose=false);
-   
+
     gv.verbose=-1;
     @testset "MP-DB - Gt-Migmatite" begin
         include("test_diagram_test4_mp.jl")
@@ -257,13 +257,11 @@ println("Testing points from the reference diagrams:")
     println("  Starting SQA Amphibole tests")
     db  = "mb"  # database: ig, igneous (Holland et al., 2018); mp, metapelite (White et al 2014b)
     data = Initialize_MAGEMin(db, verbose=false, mbCpx = 1);
-   
+
     gv.verbose=-1;
     @testset "MB-DB - SQA Amphibole" begin
         include("test_diagram_test0_mb.jl")
         TestPoints(list, data)
     end
     Finalize_MAGEMin(data)
-
-
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -107,6 +107,25 @@ end
     Finalize_MAGEMin(data)
 end
 
+@testset "view array PT" begin
+
+    data    = Initialize_MAGEMin("ig", verbose=false);
+
+    # different bulk rock per point
+    P       = [10.0, 10.0, 0]
+    T       = [1100.0, 1100.0, 0]
+    Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
+    X1      = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
+    X2      = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
+    X       = [X1,X2]
+    sys_in  = "wt"
+    P_view = @view P[1:2]
+    T_view = @view T[1:2]
+    out     = multi_point_minimization(P_view, T_view, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+
+    Finalize_MAGEMin(data)
+end
+
 @testset "convert bulk rock" begin
 
     bulk_in_ox = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -14,7 +14,7 @@ data        =   use_predefined_bulk_rock(data, test);
 # Call optimization routine for given P & T & bulk_rock
 P           =   8.0
 T           =   800.0
-out         =   point_wise_minim(P,T, data);
+out         =   point_wise_minimization(P,T, data);
 
 @show out
 
@@ -36,7 +36,7 @@ gv          =   use_predefined_bulk_rock(gv, test, db);
 gv.verbose=-1
 P           =   8.0
 T           =   800.0
-out         =   point_wise_minim(P,T, gv, z_b, DB, splx_data, sys_in);
+out         =   point_wise_minimization(P,T, gv, z_b, DB, splx_data, sys_in);
 @test out.G_system ≈ -797.7491828675325
 @test out.ph == ["spn", "cpx",  "opx", "ol"]
 @test all(abs.(out.ph_frac - [0.027985692010022857, 0.14166112328585387, 0.24227821491186913, 0.5880749697922566])  .< 1e-2)
@@ -130,7 +130,7 @@ end
     data         = use_predefined_bulk_rock(data, test)
     P           = 8.0
     T           = 1200.0
-    out         = point_wise_minim(P,T, data)
+    out         = point_wise_minimization(P,T, data)
 
     tol = 1e-2;
     @test abs(out.bulkMod - 94.98281736576462           < tol)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -48,7 +48,7 @@ finalize_MAGEMin(gv,DB,z_b)
     T       =   fill(800.0,n)
     db      =   "ig"
     data    =   Initialize_MAGEMin(db, verbose=false);
-    out     =   multi_point_minim(P, T, data, test=0);
+    out     =   multi_point_minimization(P, T, data, test=0);
     @test out[end].G_system ≈ -797.7491828675325
     @test out[end].ph == ["spn", "cpx",  "opx", "ol"]
     @test all(abs.(out[end].ph_frac - [0.027985692010022857, 0.14166112328585387, 0.24227821491186913, 0.5880749697922566])  .< 1e-2)
@@ -66,7 +66,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"
-    out     = single_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
 
     @test abs(out.G_system + 916.8283889543869)/abs(916.8283889543869) < 2e-4
 
@@ -79,7 +79,7 @@ end
     X2      = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     X       = [X1,X2]
     sys_in  = "wt"
-    out     = multi_point_minim(P, T, data, X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
 
     @test out[1].G_system ≈ -916.8283889543869 rtol=2e-4
     @test out[2].G_system ≈ -912.5920719174167 rtol=2e-4
@@ -100,7 +100,7 @@ end
     X = [[1.0], X]
     X_view = @view X[2,:]
 
-    out     = single_point_minim(P, T, data, X_view, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X_view, Xoxides=Xoxides, sys_in=sys_in)
 
     @test abs(out.G_system + 916.8283889543869)/abs(916.8283889543869) < 2e-4
 
@@ -168,7 +168,7 @@ function TestPoints(list, data::MAGEMin_Data)
     P = [ l.P for l in list]
     T = [ l.T for l in list]
     test = [ l.test for l in list]
-    out_vec = multi_point_minim(P, T, data, test = test[1]);
+    out_vec = multi_point_minimization(P, T, data, test = test[1]);
 
     # Check if the points this fit
     for (i,out) in enumerate(out_vec)


### PR DESCRIPTION
With the last version of MAGEMin_C, the new syntax for `single_point_minimization()`and `multi_point_minimization()`was introduced to allow multiple dispatch on the compositions. 

I think it would be nice to keep those as deprecated functions as it is a breaking change and the published version of MAGEMin_C is not a breaking one (still 1.3.X).
 
So I've created two new functions `single_point_minim`and `multi_point_minim`that uses the new syntax and the previous ones now send a warning.

So now this code:

```
    data    = Initialize_MAGEMin("ig", verbose=false);

    # One bulk rock for all points
    P,T     = 10.0, 1100.0
    Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
    X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
    sys_in  = "wt"
    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
```

output

```
┌ Warning: `single_point_minimization(P,T,MAGEMin_db;test=0,X=nothing,B=nothing,Xoxides=Vector{String},sys_in="mol",progressbar=true)` is deprecated, use `single_point_minim(P,T,MAGEMin_db,X;test=test,B=B,Xoxides=Xoxides,sys_in="mol",progressbar=true)` instead.
```

before the printing.

I've also done a bit cleaning. If the tests pass and you are good with that, I will also propagate the changes to MAGEMin.
