### PR TITLE
Create DocPreviewCleanup.yml

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,35 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  doc-preview-cleanup:
+    # Do not run on forks to avoid authorization errors
+    # Source: https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840/18
+    # Note: This does not always work as intended - but you can just ignore
+    #       the failed CI runs after merging a PR
+    if: github.repository_owner == 'JuliaGeodynamics'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete preview and history
+        shell: bash
+        run: |
+            git config user.name "Documenter.jl"
+            git config user.email "documenter@juliadocs.github.io"
+            git rm -rf --ignore-unmatch "previews/PR$PRNUM"
+            git commit -m "delete preview" --allow-empty
+            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+        env:
+            PRNUM: ${{ github.event.number }}
+
+      - name: Push changes
+        run: |
+            git push --force origin gh-pages-new:gh-pages
+            


### PR DESCRIPTION
When you have many PRs from branches of the repo itself (instead of from forks), Documenter.jl will build quite a lot of previews for the PRs. These previews may bloat your `gh-pages` branch. To avoid that, you can use a GitHub action like the one we're using in the Trixi.jl framework.

See also https://github.com/JuliaGeodynamics/GeophysicalModelGenerator.jl/pull/74