### PR TITLE
MAGEMin_C v1.4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MAGEMin_C"
 uuid = "e5d170eb-415a-4524-987b-12f1bce1ddab"
 authors = ["Boris Kaus <kaus@uni-mainz.de> & Nicolas Riel <riel@uni-mainz.de>"]
-version = "1.4.2"
+version = "1.4.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/gmt.history
+++ b/gmt.history
@@ -1,8 +1,0 @@
-# GMT 6 Session common arguments shelf
-BEGIN GMT 6.6.0
-B	afWSen
-J	X
-JX	X15c/0
-R	0/0.9/0/0.8
-@L	1
-END

--- a/gmt.history
+++ b/gmt.history
@@ -1,0 +1,8 @@
+# GMT 6 Session common arguments shelf
+BEGIN GMT 6.6.0
+B	afWSen
+J	X
+JX	X15c/0
+R	0/0.9/0/0.8
+@L	1
+END

--- a/src/MAGEMin.c
+++ b/src/MAGEMin.c
@@ -322,7 +322,7 @@ int runMAGEMin(			int    argc,
 										cp				);
 
 
-	gv = compute_activites (			gv.EM_database,	
+	gv = compute_activities (			gv.EM_database,	
 										gv,
 										PP_ref_db,
 										z_b				);
@@ -555,40 +555,29 @@ int runMAGEMin(			int    argc,
 		}
 	}
 	else if (gv.solver == 2){
-		int  i, ph_id;
-		int  n_ss_array[gv.len_ss];
-		for (i = 0; i < gv.len_ss; i++){
-			n_ss_array[i] = 0;
+		for (int i = 0; i < gv.len_ss; i++){
+			gv.n_ss_array[i] = 0;
 		}
 
 		double 	ig_liq = 0.0;
 		int 	n_liq  = 0;
 		int 	n_ss   = 0;
 
-		for (i = 0; i < gv.len_cp; i++){ 
+		for (int i = 0; i < gv.len_cp; i++){ 
 			if (cp[i].ss_flags[1] == 1){
-				ph_id = cp[i].id;
-				n_ss_array[ph_id] += 1;
-				if (strcmp( gv.SS_list[ph_id], "liq")  == 0){
+				gv.n_ss_array[cp[i].id] += 1;
+				if (strcmp( gv.SS_list[cp[i].id], "liq")  == 0){
 					ig_liq += cp[i].ss_n;
 					n_liq  += 1;
 				}
 			}
 		}
 
-		for (i = 0; i < gv.len_ss; i++){
-			if (n_ss_array[i] > n_ss){
-				n_ss = n_ss_array[i];
+		for (int i = 0; i < gv.len_ss; i++){
+			if (gv.n_ss_array[i] > n_ss){
+				n_ss = gv.n_ss_array[i];
 			}
 		}
-
-		gv.div 		= 0;
-		gv.status 	= 0;
-
-		/* initialize legacy solver using results of levelling phase */
-		for (i = 0; i < gv.len_ox; i++){
-			gv.gam_tot[i] = gv.gam_tot_0[i];
-		}	
 
 		if (ig_liq > 0.25 || n_liq > 2 || n_ss > 6){
 			gv 		= PGE(			z_b,									/** bulk rock constraint 			*/ 
@@ -622,6 +611,15 @@ int runMAGEMin(			int    argc,
 										cp						);
 			}
 			else{	// here we compute the LP initial guess
+
+				gv.div 		= 0;
+				gv.status 	= 0;
+
+				/* initialize legacy solver using results of levelling phase */
+				for (int i = 0; i < gv.len_ox; i++){
+					gv.gam_tot[i] = gv.gam_tot_0[i];
+				}	
+
 				gv = run_LP_ig(					z_b,
 												splx_data,
 												gv,
@@ -631,6 +629,14 @@ int runMAGEMin(			int    argc,
 			}
 		}
 		else{
+
+			gv.div 		= 0;
+			gv.status 	= 0;
+
+			/* initialize legacy solver using results of levelling phase */
+			for (int i = 0; i < gv.len_ox; i++){
+				gv.gam_tot[i] = gv.gam_tot_0[i];
+			}	
 
 			gv = LP(				z_b,									/** bulk rock informations 			*/
 									gv,										/** global variables (e.g. Gamma) 	*/
@@ -1022,11 +1028,9 @@ void FreeDatabases(		global_variable gv,
 		free(DB.SS_ref_db[i].ElEntropy);
 		free(DB.SS_ref_db[i].xi_em);
 		free(DB.SS_ref_db[i].xeos);
-		free(DB.SS_ref_db[i].xeos_sf_ok);
 
 		free(DB.SS_ref_db[i].ub);
 		free(DB.SS_ref_db[i].lb);
-		free(DB.SS_ref_db[i].tol_sf);
 
 		sym    = DB.SS_ref_db[i].symmetry;
 		if (sym == 0){
@@ -1118,7 +1122,8 @@ void FreeDatabases(		global_variable gv,
 	for (j = 0; j < ss; j++) {	free(gv.SS_list[j]);} 	free(gv.SS_list);
 	for (j = 0; j < 2; j++) {	free(gv.pdev[j]);}		free(gv.pdev);
 	for (j = 0; j < pp; j++) {	free(gv.pp_flags[j]);}	free(gv.pp_flags);
-	for (j = 0; j < n_ox*2; j++) {free(gv.A[j]);}			free(gv.A);
+	for (j = 0; j < n_ox; j++) {free(gv.A[j]);}			free(gv.A);
+	for (j = 0; j < n_ox; j++) {free(gv.A2[j]);}		free(gv.A2);
 
 	free(gv.n_SS_PC);
 	free(gv.n_min);
@@ -1156,7 +1161,12 @@ void FreeDatabases(		global_variable gv,
 	free(gv.dn_cp);
 	free(gv.dn_pp);
 	free(gv.b);
-
+	free(gv.b1);
+	free(gv.pc_id);
+	free(gv.tmp1);
+	free(gv.tmp2);
+	free(gv.tmp3);
+	free(gv.n_ss_array);
 	/* ================ z_b ============= */
 	free(z_b.apo);
 	free(z_b.masspo);

--- a/src/MAGEMin.h
+++ b/src/MAGEMin.h
@@ -67,7 +67,6 @@ typedef struct global_variables {
 	double  *work;
 
 	/* GENERAL PARAMETERS */
-	
 	int		*n_min;
 	int 	 LP;				/** linear programming stage flag	*/
 	int 	 PGE;				/** PGE stage flag				 	*/
@@ -142,7 +141,6 @@ typedef struct global_variables {
 	
 	/* LOCAL MINIMIZATION */
 	double   maxgmTime;
-	double   ineq_res;			/** relative residual for local minimization (inequality constraints)*/
 	double   obj_tol;			/** relative residual for local minimization */
 
 	double   box_size_mode_PGE;	/** edge size of the hyperdensity used during local minimization */
@@ -194,17 +192,24 @@ typedef struct global_variables {
 	double   alpha;				/** active under-relaxing factor of PGE, used to check if a phase can be reintroduced */
 	
 	/* PHASE UPDATE */ 
+	int     *n_ss_array;
+	int      ph_change;
 	double   merge_value;		/** norm distance between two instance of a solution phase under which the instances are merged into 1 */
 	double   re_in_n;			/** fraction of phase when being reintroduce.  */
 	double   re_in_df;			/** driving force under which a phase can be added back to the assemblage */
-	double   remove_dG_val; 	/** delta_G value at which a phase can be removed */ 
-	double   remove_sum_xi;		/** sum xi value at which a phase can be removed */
-	int      ph_change;
 	double 	 min_df;
 	
-	/* LEAST SQUARE OPTIMIZATION */
-	double **A;					/** save stoechiometry matrix to pass to least square optimization */
-	double  *b;					/** save bulk rock to pass to least square optimization */
+	/* LP PSEUDOCOMPOUND COMPOSITE */
+	double 	 pc_composite_dist;
+	double **A;
+	double **A2;
+	double  *b;
+	double  *b1;
+	double  *tmp1;
+	double  *tmp2;
+	double  *tmp3;
+	int     *pc_id;
+
 	double  *mass_residual;		/** bulk rock residual */
 	double   BR_norm;			/** norm of bulk rock residual  */
 	
@@ -341,9 +346,6 @@ typedef struct simplex_datas
 	double   g0_B;			/** save reference gibbs energy of pseudocompound 		*/
 	double   dG_B;			/** driving force matrix 								*/
 
-	int 	 n_local_min;
-	int 	 n_filter;
-	
 } simplex_data;
 
 /* Declare structures to hold reference gbase, composition and factor for solid solutions */
@@ -360,12 +362,14 @@ typedef struct SS_refs {
 	double   Z;
 	double   densityW;
 	double   epsilon;
-	/** end-member list */
+
+	/** end-member name list */
 	char   **EM_list;			/** solution phase list */
 	char   **CV_list;			/** solution phase list */
 
 	/** flags */
 	int     *ss_flags;			/** integer table for solution phase list 									*/
+
 	/** data needed for levelling and PGE check **/
 	int      n_pc;				/** maximum number of pseudocompounds to store 								*/
 	int     *tot_pc;			/** total number of pseudocompounds  										*/
@@ -431,8 +435,6 @@ typedef struct SS_refs {
 	
     /** data needed for local minimization **/
 	int      status;			/** status of the local minimization (ideally 0) */
-	int      nlopt_verb; 		/** verbose of NLopt, to show local iterations   							*/
-	double  *tol_sf;			/** array of tolerance for the inequality constraints 						*/
 	double  *lb;				/** array of tolerance for the inequality constraints 						*/
 	double  *ub;				/** array of tolerance for the inequality constraints 						*/
 	
@@ -458,8 +460,7 @@ typedef struct SS_refs {
 	double  *xi_em;				/** endmember fraction calculated for PGE method (depends on exp expression) */
 	double   sum_xi;			/** store sum of xi 									*/
 	double  *xeos; 				/** previous minimized x-eos	 						*/
-	double  *xeos_sf_ok;		/** save xeos that satisfy the SF 						*/
-	
+
 	/* data output */
 	double  *ElShearMod;		/** density of the endmembers 							*/
 	double  *density;			/** density of the endmembers 							*/
@@ -474,14 +475,14 @@ typedef struct IODATA {
 	int 	 n_phase;			/** number of phase for which x-eos has to be loaded 	*/
 	double 	 P;					/** prescribed pressure 								*/
 	double 	 T;					/** prescribed temperature 								*/
-	double  *in_bulk;				/** bulk rock composition if no test has been given 	*/
+	double  *in_bulk;			/** bulk rock composition if no test has been given 	*/
 	char   **phase_names;		/** solution phase names  								*/
 	double **phase_xeos;		/** solution phases compositional variables	 			*/
 	double **phase_emp;			/** solution phases endmember proportion	 			*/
 	
 } io_data;
 
-/* structure to store output data (mostly for use with julia) */
+/* structure to store output data (used for the julia wrapper) */
 typedef struct OUTDATA {
 	int 	 n_phase;			/** number of phase for which x-eos has to be loaded 	*/
 	double 	 P;					/** prescribed pressure 								*/

--- a/src/NLopt_opt_function.c
+++ b/src/NLopt_opt_function.c
@@ -1099,7 +1099,7 @@ SS_ref NLopt_opt_mb_liq_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_liq, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, liq_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, liq_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1133,7 +1133,7 @@ SS_ref NLopt_opt_mb_hb_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_hb, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, hb_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, hb_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1167,7 +1167,7 @@ SS_ref NLopt_opt_mb_aug_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_aug, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, aug_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, aug_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1200,7 +1200,7 @@ SS_ref NLopt_opt_mb_dio_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_dio, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, dio_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, dio_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1234,7 +1234,7 @@ SS_ref NLopt_opt_mb_opx_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_opx, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1268,7 +1268,7 @@ SS_ref NLopt_opt_mb_g_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_g, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1302,7 +1302,7 @@ SS_ref NLopt_opt_mb_ol_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_ol, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ol_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ol_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1336,7 +1336,7 @@ SS_ref NLopt_opt_mb_fsp_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_fsp, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fsp_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fsp_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1370,7 +1370,7 @@ SS_ref NLopt_opt_mb_abc_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_abc, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, abc_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, abc_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1404,7 +1404,7 @@ SS_ref NLopt_opt_mb_k4tr_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_k4tr, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, k4tr_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, k4tr_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1438,7 +1438,7 @@ SS_ref NLopt_opt_mb_sp_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_sp, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, sp_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, sp_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1472,7 +1472,7 @@ SS_ref NLopt_opt_mb_ilm_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_ilm, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilm_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilm_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1506,7 +1506,7 @@ SS_ref NLopt_opt_mb_ilmm_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_ilmm, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilmm_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilmm_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1540,7 +1540,7 @@ SS_ref NLopt_opt_mb_ep_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_ep, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ep_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ep_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1574,7 +1574,7 @@ SS_ref NLopt_opt_mb_bi_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_bi, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, bi_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, bi_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1608,7 +1608,7 @@ SS_ref NLopt_opt_mb_mu_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_mu, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mu_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mu_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -1642,7 +1642,7 @@ SS_ref NLopt_opt_mb_chl_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mb_chl, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, chl_mb_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, chl_mb_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -4331,7 +4331,7 @@ SS_ref NLopt_opt_mp_st_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_st, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, st_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, st_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4367,7 +4367,7 @@ SS_ref NLopt_opt_mp_sp_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_sp, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, sp_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, sp_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4403,7 +4403,7 @@ SS_ref NLopt_opt_mp_sa_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_sa, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, sa_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, sa_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4439,7 +4439,7 @@ SS_ref NLopt_opt_mp_fsp_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_fsp, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fsp_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fsp_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4475,7 +4475,7 @@ SS_ref NLopt_opt_mp_opx_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_opx, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4511,7 +4511,7 @@ SS_ref NLopt_opt_mp_mu_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_mu, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mu_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mu_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4547,7 +4547,7 @@ SS_ref NLopt_opt_mp_mt_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_mt, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mt_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mt_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4583,7 +4583,7 @@ SS_ref NLopt_opt_mp_ma_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_ma, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ma_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ma_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4618,7 +4618,7 @@ SS_ref NLopt_opt_mp_ilm_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_ilm, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilm_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilm_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -4652,7 +4652,7 @@ SS_ref NLopt_opt_mp_ilmm_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_ilmm, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilmm_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilmm_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4688,7 +4688,7 @@ SS_ref NLopt_opt_mp_g_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_g, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4724,7 +4724,7 @@ SS_ref NLopt_opt_mp_ep_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_ep, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ep_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ep_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4760,7 +4760,7 @@ SS_ref NLopt_opt_mp_ctd_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_ctd, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ctd_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ctd_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4796,7 +4796,7 @@ SS_ref NLopt_opt_mp_chl_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_chl, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, chl_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, chl_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4832,7 +4832,7 @@ SS_ref NLopt_opt_mp_cd_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_cd, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, cd_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, cd_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4868,7 +4868,7 @@ SS_ref NLopt_opt_mp_bi_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_bi, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, bi_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, bi_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4905,7 +4905,7 @@ SS_ref NLopt_opt_mp_liq_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_mp_liq, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, liq_mp_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, liq_mp_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -4941,7 +4941,7 @@ SS_ref NLopt_opt_ig_fper_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_ig_fper, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fper_ig_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fper_ig_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     
@@ -4976,7 +4976,7 @@ SS_ref NLopt_opt_ig_bi_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_bi, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, bi_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, bi_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5010,7 +5010,7 @@ SS_ref NLopt_opt_ig_cd_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_cd, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, cd_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, cd_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5046,7 +5046,7 @@ SS_ref NLopt_opt_ig_cpx_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_cpx, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, cpx_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, cpx_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5081,7 +5081,7 @@ SS_ref NLopt_opt_ig_ep_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_ep, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ep_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ep_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5116,7 +5116,7 @@ SS_ref NLopt_opt_ig_fl_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_fl, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fl_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fl_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5151,7 +5151,7 @@ SS_ref NLopt_opt_ig_g_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_g, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5186,7 +5186,7 @@ SS_ref NLopt_opt_ig_hb_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_hb, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, hb_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, hb_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5221,7 +5221,7 @@ SS_ref NLopt_opt_ig_ilm_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_ilm, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilm_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ilm_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5256,7 +5256,7 @@ SS_ref NLopt_opt_ig_liq_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_liq, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, liq_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, liq_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5291,7 +5291,7 @@ SS_ref NLopt_opt_ig_mu_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_mu, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mu_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, mu_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5326,7 +5326,7 @@ SS_ref NLopt_opt_ig_ol_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_ol, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ol_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ol_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5361,7 +5361,7 @@ SS_ref NLopt_opt_ig_opx_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_opx, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5396,7 +5396,7 @@ SS_ref NLopt_opt_ig_fsp_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_fsp, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fsp_ig_c, NULL, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fsp_ig_c, NULL, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
    
@@ -5431,7 +5431,7 @@ SS_ref NLopt_opt_ig_spn_function(global_variable gv, SS_ref SS_ref_db){
    nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
    nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
    nlopt_set_min_objective(SS_ref_db.opt, obj_ig_spn, &SS_ref_db);
-   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, spn_ig_c, &SS_ref_db, SS_ref_db.tol_sf);
+   nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, spn_ig_c, &SS_ref_db, NULL);
    nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
    nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
 
@@ -5469,7 +5469,7 @@ SS_ref NLopt_opt_um_fluid_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_fluid, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fluid_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, fluid_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5505,7 +5505,7 @@ SS_ref NLopt_opt_um_ol_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_ol, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ol_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ol_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5541,7 +5541,7 @@ SS_ref NLopt_opt_um_br_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_br, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, br_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, br_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5577,7 +5577,7 @@ SS_ref NLopt_opt_um_ch_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_ch, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ch_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ch_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5613,7 +5613,7 @@ SS_ref NLopt_opt_um_atg_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_atg, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, atg_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, atg_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5649,7 +5649,7 @@ SS_ref NLopt_opt_um_g_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_g, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, g_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5685,7 +5685,7 @@ SS_ref NLopt_opt_um_ta_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_ta, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ta_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, ta_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5721,7 +5721,7 @@ SS_ref NLopt_opt_um_chl_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_chl, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, chl_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, chl_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5757,7 +5757,7 @@ SS_ref NLopt_opt_um_anth_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_anth, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, anth_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, anth_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5793,7 +5793,7 @@ SS_ref NLopt_opt_um_spi_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_spi, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, spi_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, spi_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5829,7 +5829,7 @@ SS_ref NLopt_opt_um_opx_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_opx, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, opx_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5865,7 +5865,7 @@ SS_ref NLopt_opt_um_po_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_um_po, &SS_ref_db);
-    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, po_um_c, NULL, SS_ref_db.tol_sf);
+    nlopt_add_inequality_mconstraint(SS_ref_db.opt, m, po_um_c, NULL, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);
@@ -5932,7 +5932,7 @@ SS_ref NLopt_opt_aq17_function(global_variable gv, SS_ref SS_ref_db){
     nlopt_set_lower_bounds(SS_ref_db.opt, SS_ref_db.lb);
     nlopt_set_upper_bounds(SS_ref_db.opt, SS_ref_db.ub);
     nlopt_set_min_objective(SS_ref_db.opt, obj_aq17, &SS_ref_db);
-    nlopt_add_equality_mconstraint(SS_ref_db.opt, m, aq17_c, &SS_ref_db, SS_ref_db.tol_sf);
+    nlopt_add_equality_mconstraint(SS_ref_db.opt, m, aq17_c, &SS_ref_db, NULL);
     nlopt_set_ftol_rel(SS_ref_db.opt, gv.obj_tol);
     nlopt_set_maxeval(SS_ref_db.opt, gv.maxeval);
     // nlopt_set_maxtime(SS_ref_db.opt, gv.maxgmTime);

--- a/src/gss_init_function.c
+++ b/src/gss_init_function.c
@@ -1371,7 +1371,6 @@ SS_ref G_SS_init_EM_function(		int			 		 ph_id,
 	SS_ref_db.ElEntropy		= malloc (gv.len_ox  	* sizeof (double) );     
 	SS_ref_db.xi_em   		= malloc (n_em   	 	* sizeof (double) ); 
 	SS_ref_db.xeos    		= malloc (n_xeos     	* sizeof (double) ); 	
-	SS_ref_db.xeos_sf_ok 	= malloc ((n_xeos) 		* sizeof (double) );
 
 	/* memory allocation to store all gbase */
 	SS_ref_db.mu_array = malloc ((gv.n_Diff) * sizeof (double*) ); 
@@ -1388,11 +1387,7 @@ SS_ref G_SS_init_EM_function(		int			 		 ph_id,
 	/* dynamic memory allocation of data to send to NLopt */
 	SS_ref_db.ub   		= malloc ((n_xeos) * sizeof (double) ); 
 	SS_ref_db.lb   		= malloc ((n_xeos) * sizeof (double) ); 
-	SS_ref_db.tol_sf   	= malloc ((n_sf) * sizeof (double) ); 
-	for (int j = 0; j < n_sf; j++){
-		SS_ref_db.tol_sf[j] = gv.ineq_res;
-	}
-	
+
 	/**
 		Allocate memory for levelling pseudocompounds 
 	*/

--- a/src/ss_min_function.h
+++ b/src/ss_min_function.h
@@ -33,7 +33,13 @@ void ss_min_LP(							global_variable 	 gv,
 										bulk_info 	 		 z_b,
 										SS_ref 				*SS_ref_db,
 										csd_phase_set  		*cp				);
-										
+
+int	copy_to_Ppc_composite(				int 				 ph_id,
+										global_variable 	 gv,
+
+										obj_type 			*SS_objective,
+										SS_ref 			    *SS_ref_db		);		
+
 void copy_to_cp(						int 				 i, 
 										int 				 ph_id,
 										global_variable 	 gv,

--- a/src/toolkit.c
+++ b/src/toolkit.c
@@ -123,7 +123,25 @@ void print_2D_double_array(double nx, double ny, double **array, char *title){
 		printf("\n");
 	}
 	printf("\n");
+}
 
+void print_1D_double_array(double nx, double *array, char *title){
+	int j;
+	printf(" %s:\n",title);
+	for (j = 0; j < nx; j++){
+		printf(" %+10f",array[j]);
+	}
+	printf("\n");
+}
+
+
+void print_1D_int_array(double nx, int *array, char *title){
+	int j;
+	printf(" %s:\n",title);
+	for (j = 0; j < nx; j++){
+		printf(" %d",array[j]);
+	}
+	printf("\n");
 }
 
 /* generate a random double between 0 and a*/
@@ -1474,7 +1492,7 @@ global_variable compute_density_volume_modulus(				int 				 EM_database,
 }
 
 
-global_variable compute_activites(			int					 EM_database,	
+global_variable compute_activities(			int					 EM_database,	
 											global_variable 	 gv,
 											PP_ref  			*PP_ref_db,
 											bulk_info 			 z_b			){

--- a/src/toolkit.h
+++ b/src/toolkit.h
@@ -30,7 +30,10 @@ int 	get_active_em(double *array, int n);
 int 	EndsWithTail(char *name, char* tail);	
 int    	RootBracketed(double x1,double x2);
 
+void 	print_1D_double_array(double nx, double *array, char *title);
 void 	print_2D_double_array(double nx, double ny, double **array, char *title);
+void 	print_1D_int_array(double nx, int *array, char *title);
+
 double  rnd(double a);
 double  SUPCRT_to_HSC(double *ElH, double *comp, int size);
 double  HSC_to_SUPCRT(double *ElH, double *comp, int size);
@@ -106,7 +109,7 @@ global_variable compute_phase_mol_fraction(	global_variable 	 gv,
 											SS_ref  			*SS_ref_db,
 											csd_phase_set  		*cp					);
 
-global_variable compute_activites(			int					 EM_database,	
+global_variable compute_activities(			int					 EM_database,	
 											global_variable 	 gv,
 											PP_ref  			*PP_ref_db,
 											bulk_info 			 z_b				);

--- a/test/test_problematic_points.jl
+++ b/test/test_problematic_points.jl
@@ -9,7 +9,7 @@ data    = Initialize_MAGEMin("ig", verbose=1, solver=2);
 
 # One bulk rock for all points
 P,T     = 8.42, 705.0
-Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
+Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "K2O"; "Na2O"; "TiO2"; "O"; "Cr2O3"; "H2O"];
 X       = [31.8;  8.28 ; 2.1;  0.1;  13.9;  0.0 ; 2.2;  4.2;  0.0;  0.0; 37.4];
 sys_in  = "mol"    
 out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -269,8 +269,6 @@ println("Testing points from the reference diagrams:")
 
 end
 
-
-
 # a few tests that gave problems in the past
 println("Testing problematic points:")
 @testset verbose = true "Problematic points" begin


### PR DESCRIPTION
- Corrects issue when maximum of PC is reached
- Switch from PGE to LP solver is more aggressive now (catches when norm(gamma) goes crazy)
- Uses the right julia wrapper method to copy bulk_rock and avoid (rare) related segfaults
- Improved initialization of the different solvers
- Extended clean up of allocated but unused arrays