### PR TITLE
Add name_solvus kwarg to pwm_run()

### DIFF
--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -1409,7 +1409,7 @@ end
 pwm_init(P::Number,T::Number, gv, z_b, DB, splx_data) = pwm_init(Float64(P),Float64(T), gv, z_b, DB, splx_data)
 
 
-function pwm_run(gv, z_b, DB, splx_data)
+function pwm_run(gv, z_b, DB, splx_data; name_solvus = false)
     input_data      =   LibMAGEMin.io_data();                           # zero (not used actually)
 
     time = @elapsed  gv      = LibMAGEMin.ComputeEquilibrium_Point(gv.EM_database, input_data, z_b, gv, pointer_from_objref(splx_data),	DB.PP_ref_db,DB.SS_ref_db,DB.cp);
@@ -1424,7 +1424,7 @@ function pwm_run(gv, z_b, DB, splx_data)
     LibMAGEMin.PrintOutput(gv, 0, 1, DB, time, z_b);
 
     # Transform results to a more convenient julia struct
-    out = create_gmin_struct(DB, gv, time);
+    out = create_gmin_struct(DB, gv, time, name_solvus = name_solvus);
 
     # LibMAGEMin.FreeDatabases(gv, DB, z_b);
 


### PR DESCRIPTION
Hello,

I suggest, adding the option to rename the phases in the gmin_struct using the solvus names also when minimising with `pwm_run`, instead of `point_wise_minimization`. This addition would be very useful for some routines in [ThermoFit.jl](https://github.com/neoscalc/ThermoFit.jl).  I am not aware of the extent to which others use `pwm_init` and `pwm_run`, so please let me know if this could have consequences I am unaware of.

I look forward to hearing your thoughts on this. I would also be very happy to add an additional test for a call of pwm_run using the new keyword argument if you consider this necessary.

Cheers, Philip

